### PR TITLE
Add bare test vectors

### DIFF
--- a/poc/frost.sage
+++ b/poc/frost.sage
@@ -279,8 +279,8 @@ sig = signers[1].aggregate(group_comm, sig_shares, participant_list, signer_publ
 final_output = {
     "sig": {}
 }
-final_output["sig"]["commitment"] = to_hex(G.serialize(sig[0]))
-final_output["sig"]["commitment"] = to_hex(G.serialize_scalar(sig[1]))
+final_output["sig"]["R"] = to_hex(G.serialize(sig[0]))
+final_output["sig"]["z"] = to_hex(G.serialize_scalar(sig[1]))
 
 def generate_schnorr_signature(G, H, sk, msg):
     pk = sk * G.generator()

--- a/poc/groups.sage
+++ b/poc/groups.sage
@@ -164,43 +164,6 @@ class GroupP521(GroupNISTCurve):
         gy = 0x11839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650
         GroupNISTCurve.__init__(self, "P521_XMD:SHA-512_SSWU_RO_", p521_sswu_ro, p521_F, p521_A, p521_B, p521_p, p521_order, gx, gy, 98, hashlib.sha512, expand_message_xmd, 256)
 
-class GroupEd25519(Group):
-    def __init__(self):
-        Group.__init__(self, "ed25519")
-        self.k = 128
-        self.L = 48
-        self.field_bytes_length = 32
-
-    def generator(self):
-        return Ed25519Point().base()
-
-    def order(self):
-        return Ed25519Point().order
-
-    def identity(self):
-        return Ed25519Point().identity()
-
-    def serialize(self, element):
-        return element.encode()
-
-    def deserialize(self, encoded):
-        return Ed25519Point().decode(encoded)
-
-    def serialize_scalar(self, scalar):
-        return I2OSP(scalar % self.order(), self.scalar_byte_length())[::-1]
-
-    def element_byte_length(self):
-        return self.field_bytes_length
-
-    def scalar_byte_length(self):
-        return self.field_bytes_length
-
-    def hash_to_group(self, msg, dst):
-        return Ed25519Point().hash_to_group(msg, dst)
-
-    def hash_to_scalar(self, msg, dst=""):
-        return hash_to_field(msg, 1, dst, self.order(), 1, self.L, expand_message_xmd, hashlib.sha512, self.k)[0][0]
-
 class GroupRistretto255(Group):
     def __init__(self):
         Group.__init__(self, "ristretto255")

--- a/poc/groups.sage
+++ b/poc/groups.sage
@@ -164,6 +164,43 @@ class GroupP521(GroupNISTCurve):
         gy = 0x11839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650
         GroupNISTCurve.__init__(self, "P521_XMD:SHA-512_SSWU_RO_", p521_sswu_ro, p521_F, p521_A, p521_B, p521_p, p521_order, gx, gy, 98, hashlib.sha512, expand_message_xmd, 256)
 
+class GroupEd25519(Group):
+    def __init__(self):
+        Group.__init__(self, "ed25519")
+        self.k = 128
+        self.L = 48
+        self.field_bytes_length = 32
+
+    def generator(self):
+        return Ed25519Point().base()
+
+    def order(self):
+        return Ed25519Point().order
+
+    def identity(self):
+        return Ed25519Point().identity()
+
+    def serialize(self, element):
+        return element.encode()
+
+    def deserialize(self, encoded):
+        return Ed25519Point().decode(encoded)
+
+    def serialize_scalar(self, scalar):
+        return I2OSP(scalar % self.order(), self.scalar_byte_length())[::-1]
+
+    def element_byte_length(self):
+        return self.field_bytes_length
+
+    def scalar_byte_length(self):
+        return self.field_bytes_length
+
+    def hash_to_group(self, msg, dst):
+        return Ed25519Point().hash_to_group(msg, dst)
+
+    def hash_to_scalar(self, msg, dst=""):
+        return hash_to_field(msg, 1, dst, self.order(), 1, self.L, expand_message_xmd, hashlib.sha512, self.k)[0][0]
+
 class GroupRistretto255(Group):
     def __init__(self):
         Group.__init__(self, "ristretto255")


### PR DESCRIPTION
First part of #49. It adds test vector generation for ristretto255 with one (2,3) participant configuration. We can extend this in a followup change to iterate through more subsets. Of course, I'm open to renaming or restructuring anything differently!

Example output:

```
{
  "config": {
    "NUM_SIGNERS": "3",
    "THRESHOLD_LIMIT": "2",
    "group": "ristretto255",
    "hash": "SHA512"
  },
  "inputs": {
    "group_secret_key": "c604c785ada70d77a5256ae21767de8c3304115237d262134f5e46e512cf8e03",
    "group_public_key": "0ca5c9fa211b6c240e4e7af6c6cf624c7b0fd1f8916eacbb6518267f332db951",
    "message": "74657374",
    "signers": {
      "1": {
        "signer_share": "24dd5ca618a461a81256e505fcd5aaf356b3c45aa479a49cf3744710f306740f"
      },
      "2": {
        "signer_share": "95e1fc69693da381a9e96886014b98457a6278631121e625988b483bd33e590b"
      },
      "3": {
        "signer_share": "06e69c2dbad6e45a407dec0607c085979d112c6c7ec827af3ca24966b3763e07"
      }
    }
  },
  "round_one_outputs": {
    "participants": [
      "1",
      "2"
    ],
    "commitment_list": "000000018a9049503ade17c922b4ab93e0fd7802f8986ee4cdd25d7e2da2691139160c15eee7a9c7fec3460c27c160c683d46a4fd18f537c055c3998748b8e4cd8f29b3e00000002d88068bbb009b13a005e66b143d52591f4081f4b3b342ebc4035af868ba82f7b3647dbbc9e46bd45cd1fe21d6197971b84e3ae2a7a165aaade49ee2ebf1eba5a",
    "group_blinding_factor": "675146437df1bbc42f8fa74673c2c6a5393bb469a02c1402d497428575b55900",
    "outputs": {
      "1": {
        "hiding_nonce": "ed8366feb6b1d05d1f46acb727061e43aadfafe9c10e5a64e7518d63e3263503",
        "blinding_nonce": "019cbd1d7420292528f8cdd62f339fdabb602f04a95dac9dbcec831b8c681a09",
        "hiding_nonce_commitment": "8a9049503ade17c922b4ab93e0fd7802f8986ee4cdd25d7e2da2691139160c15",
        "blinding_nonce_commitment": "eee7a9c7fec3460c27c160c683d46a4fd18f537c055c3998748b8e4cd8f29b3e"
      },
      "2": {
        "hiding_nonce": "89c61a42c8191a5ca41f2fe959843d333bcf43173b7de4c5c119e0e0d8b0e707",
        "blinding_nonce": "e6d0f1d89ad552e383d6c6f4e8598cc3037d6e274d22da3089e7afbd4171ea02",
        "hiding_nonce_commitment": "d88068bbb009b13a005e66b143d52591f4081f4b3b342ebc4035af868ba82f7b",
        "blinding_nonce_commitment": "3647dbbc9e46bd45cd1fe21d6197971b84e3ae2a7a165aaade49ee2ebf1eba5a"
      }
    }
  },
  "round_two_outputs": {
    "participants": [
      "1",
      "2"
    ],
    "outputs": {
      "1": {
        "sig_share": "949f570b01bb3da189e1138fa4a1637ebaef75afb7ba97a0e1e147e204a3c800",
        "group_commitment_share": "aad18ee8e1aa4e0a1fc5da36aab1ed0b138a503e14a2dba771b2c170efd00f34"
      },
      "2": {
        "sig_share": "0bbfe9944fa5e6f9aefe5b663598719305e0aad0f9e438318bce9e9f281e7d01",
        "group_commitment_share": "8613328b9f574fdf988f60593da63ad3d2645ab62010048dccf65b6c3504a60a"
      }
    }
  },
  "final_output": {
    "sig": {
      "R": "828e92dec234c47d60f9fc4b2bb6c794b06e83d0a6be9479dd8e3fc66c69cf3e",
      "z": "9f5e41a05060249b38e06ff5d939d511c0cf2080b19fd0d16cb0e6812dc14502"
    }
  }
}
```