### PR TITLE
RFC8032 compat with some open questions

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -279,9 +279,9 @@ written as H, which functions effectively as a random oracle. For concrete
 recommendations on hash functions which SHOULD BE used in practice, see
 {{ciphersuites}}. Using H, we introduce three separate domain-separated hashes,
 H1, H2, and H3, where H1 and H2 map arbitrary inputs to non-zero Scalar elements of
-the prime-order group scalar field, and H3 is an alias for H. The details of
-H1, H2, and H3 vary based on ciphersuite. See {{ciphersuites}} for more details
-about each.
+the prime-order group scalar field, and H3 is an alias for H with domain separation
+applied. The details of H1, H2, and H3 vary based on ciphersuite. See {{ciphersuites}}
+for more details about each.
 
 # Helper functions {#helpers}
 

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -40,7 +40,10 @@ normative:
     author:
       -
         org: ANSI
-
+  SECG:
+    title: "Elliptic Curve Cryptography, Standards for Efficient Cryptography Group, ver. 2"
+    target: https://secg.org/sec1-v2.pdf
+    date: 2009
 informative:
   FROST20:
     target: https://eprint.iacr.org/2020/852.pdf
@@ -239,9 +242,6 @@ We now detail a number of member functions that can be invoked on a prime-order 
 
 - Order(): Outputs the order of `G` (i.e. `p`).
 - Identity(): Outputs the identity element of the group (i.e. `I`).
-- HashToScalar(x): A member function of `G` that deterministically maps
-  an array of bytes `x` to an element in GF(p). This function is optionally
-  parameterized by a DST.
 - RandomScalar(): A member function of `G` that chooses at random a
   non-zero element in GF(p).
 - SerializeElement(A): A member function of `G` that maps a group element `A`
@@ -252,13 +252,6 @@ We now detail a number of member functions that can be invoked on a prime-order 
   byte representation of an element. This function can raise a
   DeserializeError if deserialization fails or `A` is the identity element
   of the group; see {{input-validation}}.
-- SerializeScalar(s): A member function of `G` that maps a scalar element `s`
-  to a unique byte array `buf` of fixed length `Ns`. The output type of this
-  function is `SerializedScalar`.
-- DeserializeScalar(buf): A member function of `G` that maps a byte array
-  `buf` to a scalar `s`, or fails if the input is not a valid byte
-  representation of a scalar. This function can raise a
-  DeserializeError if deserialization fails; see {{input-validation}}.
 
 ### Input Validation {#input-validation}
 
@@ -284,23 +277,11 @@ little-endian integer, is a value greater than or equal to 0, and less than `Ord
 FROST requires the use of a cryptographically secure hash function, generically
 written as H, which functions effectively as a random oracle. For concrete
 recommendations on hash functions which SHOULD BE used in practice, see
-{{ciphersuites}}. By construction, the hash functions inputs MUST be smaller
-than 2^64 bits.
-
-Using H, we introduce two separate domain-separated hashes, H1, H2, and H3.
-These hash functions differ per parameter set, so H1, H2, and H3 differ
-between instantiations of the protocol as follows:
-
-~~~
-H1(m) = H(contextString || "rho" || I2OSP(len(m), 8) || m)
-H2(m) = H(contextString || "chal" || I2OSP(len(m), 8) || m)
-H3(m) = H(m)
-~~~
-
-Normally H3 would also include a domain separator, but for backwards compatibility
-with {{!RFC8032}}, it is omitted here.
-
-The variable contextString is unique for each ciphersuite defined in {{ciphersuites}}.
+{{ciphersuites}}. Using H, we introduce three separate domain-separated hashes,
+H1, H2, and H3, where H1 and H2 map arbitrary inputs to non-zero Scalar elements of
+the prime-order group scalar field, and H3 is an alias for H. The details of
+H1, H2, and H3 vary based on ciphersuite. See {{ciphersuites}} for more details
+about each.
 
 # Helper functions {#helpers}
 
@@ -464,19 +445,19 @@ structures into values that can be processed with hash functions.
 
 ~~~
   Inputs:
-  - commitment_list = [(j, D_j, E_j), ...], a list of commitments issued by each signer,
+  - commitment_list = [(i, x, y), ...], a list of commitments issued by each signer,
     where each element in the list indicates the signer index and their
-    two commitment Element values. B MUST be sorted in ascending order
+    two commitment Element values (x, y). This list MUST be sorted in ascending order
     by signer index.
 
-  Outputs: A byte string containing the serialized representation of B.
+  Outputs: A byte string containing the serialized representation of commitment_list.
 
   def encode_group_commitment_list(commitment_list):
     encoded_group_commitment = nil
-    for (j, D_j, E_j) in B:
-      encoded_commitment = I2OSP(j, 2) ||
-                           G.SerializeElement(D_j) ||
-                           G.SerializeElement(E_j)
+    for (index, hiding_nonce_commitment, blinding_nonce_commitment) in commitment_list:
+      encoded_commitment = I2OSP(index, 2) ||
+                           G.SerializeElement(hiding_nonce_commitment) ||
+                           G.SerializeElement(blinding_nonce_commitment)
       encoded_group_commitment = encoded_group_commitment || encoded_commitment
     return encoded_group_commitment
 ~~~
@@ -524,8 +505,8 @@ signature; see {{sec-considerations}}.
 Round one involves each signer generating a pair of nonces and their corresponding public
 commitments. A nonce is a pair of Scalar values, and a commitment is a pair of Element values.
 
-Each signer in round one generates a nonce `nonce = (d, e)` and commitment
-`comm = (D, E)` for each signer.
+Each signer in round one generates a nonce `nonce = (hiding_nonce, blinding_nonce)` and commitment
+`comm = (hiding_nonce_commitment, blinding_nonce_commitment)` for each signer.
 
 ~~~
   Inputs: None
@@ -533,16 +514,16 @@ Each signer in round one generates a nonce `nonce = (d, e)` and commitment
   Outputs: (nonce, comm), a tuple of nonce and nonce commitment pairs.
 
   def commit():
-    d = G.RandomScalar()
-    e = G.RandomScalar()
-    D = G.ScalarBaseMult(d)
-    E = G.ScalarBaseMult(e)
-    nonce = (d, e)
-    comm = (D, E)
-    return nonce, comm
+    hiding_nonce = G.RandomScalar()
+    blinding_nonce = G.RandomScalar()
+    hiding_nonce_commitment = G.ScalarBaseMult(hiding_nonce)
+    blinding_nonce_commitment = G.ScalarBaseMult(blinding_nonce)
+    nonce = (hiding_nonce, blinding_nonce)
+    comm = (hiding_nonce_commitment, blinding_nonce_commitment)
+    return (nonce, comm)
 ~~~
 
-The output `nonce` from Participant `P_i` is stored locally and kept private
+The private output `nonce` from Participant `P_i` is stored locally and kept private
 for use in the second round. The public output `comm` from Participant `P_i`
 is sent to the Coordinator; see {{encode-commitment}} for encoding recommendations.
 
@@ -568,14 +549,15 @@ each Signer then runs the following procedure to produce its own signature share
   - nonce_i, pair of Scalar values (d, e) generated in round one.
   - comm_i, pair of Element values (D, E) generated in round one.
   - msg, the message to be signed (sent by the Coordinator).
-  - commitment_list = [(j, D_j, E_j), ...], a list of commitments issued by each signer,
+  - commitment_list = [(j, x, y), ...], a list of commitments issued by each signer,
     where each element in the list indicates the signer index and their
-    two commitment Element values. B MUST be sorted in ascending order
+    two commitment Element values (x, y). This list MUST be sorted in ascending order
     by signer index.
   - participant_list, a set containing identifiers for each signer, similarly of length
     NUM_SIGNERS (sent by the Coordinator).
 
-  Outputs: a signature share z_i and commitment share R_i
+  Outputs: a signature share sig_share and commitment share comm_share, which
+           are Element and Scalar values respectively.
 
   def sign(index, sk, group_public_key, nonce, comm, msg, commitment_list, participant_list):
     # Compute the blinding factor
@@ -585,8 +567,8 @@ each Signer then runs the following procedure to produce its own signature share
 
     # Compute the group commitment
     R = G.Identity()
-    for (_, D_i, E_i) in B:
-      R = R + (D_i + (E_i * blinding_factor))
+    for (_, hiding_nonce_commitment, blinding_nonce_commitment) in B:
+      R = R + (hiding_nonce_commitment + (blinding_nonce_commitment * blinding_factor))
 
     lambda_i = derive_lagrange_coefficient(index, participant_list)
 
@@ -595,17 +577,17 @@ each Signer then runs the following procedure to produce its own signature share
     group_comm_enc = G.SerializeElement(R)
     group_public_key_enc = G.SerializeElement(group_public_key)
     challenge_input = group_comm_enc || group_public_key_enc || msg_hash
-    c = H2(challenge_input)
+    c = H(challenge_input)
 
     # Compute the signature share
-    (d, e) = nonce_i
-    z_i = d + (e * blinding_factor) + (lambda_i * sk_i * c)
+    (hiding_nonce, blinding_nonce) = nonce_i
+    sig_share = hiding_nonce + (blinding_nonce * blinding_factor) + (lambda_i * sk_i * c)
 
     # Compute the commitment share
-    (D, E) = comm_i
-    R_i = D + (E * blinding_factor)
+    (hiding_nonce_commitment, blinding_nonce_commitment) = comm_i
+    comm_share = hiding_nonce_commitment + (blinding_nonce_commitment * blinding_factor)
 
-    return z_i, R_i
+    return sig_share, comm_share
 ~~~
 
 The output of this procedure is a signature share and group commitment share.
@@ -620,26 +602,26 @@ The Coordinator MUST verify the set of signature shares using the following proc
   - index, Index `i` of the signer. Note index will never equal `0`.
   - PK, the public key for the group
   - PK_i, the public key for the ith signer, where PK_i = ScalarBaseMult(s[i])
-  - z_i, the signature share for the ith signer, computed from the signer
-  - R_i, the commitment for the ith signer, computed from the signer
+  - sig_share, the signature share for the ith signer, computed from the signer
+  - comm_share, the commitment for the ith signer, computed from the signer
   - R, the group commitment
   - msg, the message to be signed
   - participant_list, a set containing identifiers for each signer, similarly of length
     NUM_SIGNERS (sent by the Coordinator).
 
-  Outputs: 1 if the signature share is valid, and 0 otherwise
+  Outputs: 1 if the signature share is valid, and 0 otherwise.
 
-  def verify_signature_share(index, PK, PK_i, z_i, R_i, R, msg, participant_list):
+  def verify_signature_share(index, PK, PK_i, sig_share, comm_share, R, msg, participant_list):
     msg_hash = H3(msg)
     group_comm_enc = G.SerializeElement(R)
     group_public_key_enc = G.SerializeElement(group_public_key)
     challenge_input = group_comm_enc || group_public_key_enc || msg_hash
-    c = H2(challenge_input)
+    c = H(challenge_input)
 
-    l = G.ScalarbaseMult(z_i)
+    l = G.ScalarbaseMult(sig_share)
 
     lambda_i = derive_lagrange_coefficient(index, participant_list)
-    r = R_i + (z_i * c * lambda_i)
+    r = comm_share + (sig_share * c * lambda_i)
 
     return l == r
 ~~~
@@ -674,6 +656,29 @@ A FROST ciphersuite must specify the underlying prime-order group details
 and cryptographic hash function. Each ciphersuite is denoted as (Group, Hash),
 e.g., (ristretto255, SHA-512). This section contains some ciphersuites.
 The RECOMMENDED ciphersuite is (ristretto255, SHA-512) {{recommended-suite}}.
+The (edwards25519, SHA-512) ciphersuite is included for backwards compatibility
+with {{!RFC8032}}.
+
+## FROST(edwards25519, SHA-512)
+
+This ciphersuite uses edwards25519 for the Group and SHA-512 for the Hash function `H`
+meant to produce signatures indistinguishable from Ed25519 as specified in {{!RFC8032}}.
+The value of the contextString parameter is empty.
+
+- Group: ed25519 {{!RFC8032}}
+  - SerializeElement: Implemented as specified in {{!RFC8032, Section 5.1.2}}.
+  - DeserializeElement: Implemented as specified in {{!RFC8032, Section 5.1.3}}.
+- Hash (`H`): SHA-512, and Nh = 64.
+  - H1(m): Implemented by computing H("rho" || m), interpreting the lower
+    32 bytes as a little-endian integer, and reducing the resulting integer modulo
+    L = 2^252+27742317777372353535851937790883648493.
+  - H2(m): Implemented by computing H(m), interpreting the lower 32 bytes
+    as a little-endian integer, and reducing the resulting integer modulo
+    L = 2^252+27742317777372353535851937790883648493.
+  - H3(m): Implemented as an alias for H, i.e., H(m).
+
+Normally H2 would also include a domain separator, but for backwards compatibility
+with {{!RFC8032}}, it is omitted.
 
 ## FROST(ristretto255, SHA-512) {#recommended-suite}
 
@@ -681,15 +686,14 @@ This ciphersuite uses ristretto255 for the Group and SHA-512 for the Hash functi
 The value of the contextString parameter is "FROST-RISTRETTO255-SHA512".
 
 - Group: ristretto255 {{!RISTRETTO=I-D.irtf-cfrg-ristretto255-decaf448}}
-  - HashToScalar(): Compute `uniform_bytes` using `expand_message` = `expand_message_xmd`,
-    DST = "HashToScalar-" || contextString, and output length 64, interpret
-    `uniform_bytes` as a 512-bit integer in little-endian order, and reduce the integer
-    modulo `Order()`.
-  - Serialization: Both group elements and scalars are encoded in Ne = Ns = 32
-    bytes. For group elements, use the 'Encode' and 'Decode' functions from
-    {{!RISTRETTO}}. For scalars, ensure they are fully reduced modulo `Order()`
-    and in little-endian order.
+  - SerializeElement: Implemented using the 'Encode' function from {{!RISTRETTO}}.
+  - DeserializElement: Implemented using the 'Decode' function from {{!RISTRETTO}}.
 - Hash (`H`): SHA-512, and Nh = 64.
+  - H1(m): Implemented by computing H(contextString || "rho" || m) and mapping the
+    the output to a Scalar as described in {{!RISTRETTO, Section 4.4}}.
+  - H2(m): Implemented by computing H(contextString || "chal" || m) and mapping the
+    the output to a Scalar as described in {{!RISTRETTO, Section 4.4}}.
+  - H3(m): Implemented as an alias for H, i.e., H(m).
 
 ## FROST(P-256, SHA-256)
 
@@ -697,12 +701,21 @@ This ciphersuite uses P-256 for the Group and SHA-256 for the Hash function `H`.
 The value of the contextString parameter is "FROST-P256-SHA256".
 
 - Group: P-256 (secp256r1) {{x9.62}}
-  - HashToScalar(): Use hash_to_field from {{!I-D.irtf-cfrg-hash-to-curve}}
-    using L = 48, `expand_message_xmd` with SHA-256,
-    DST = "HashToScalar-" || contextString, and
-    prime modulus equal to `Order()`.
+  - SerializeElement: Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
+    method according to {{SECG}}.
+  - DeserializeElement: Implemented by attempting to deserialize a public key using
+    the compressed Octet-String-to-Elliptic-Curve-Point method according to {{SECG}},
+    and then performs partial public-key validation as defined in section 5.6.2.3.4 of
+    {{!KEYAGREEMENT=DOI.10.6028/NIST.SP.800-56Ar3}}.
   - Serialization: Elements are serialized as Ne = 33 byte string
 - Hash (`H`): SHA-256, and Nh = 32.
+  - H1(m): Implemented using hash_to_field from {{!HASH-TO-CURVE=I-D.irtf-cfrg-hash-to-curve, Section 5.3}}
+    using L = 48, `expand_message_xmd` with SHA-256, DST = contextString || "rho", and
+    prime modulus equal to `Order()`.
+  - H2(m): Implemented using hash_to_field from {{!HASH-TO-CURVE, Section 5.3}}
+    using L = 48, `expand_message_xmd` with SHA-256, DST = contextString || "chal", and
+    prime modulus equal to `Order()`.
+  - H3(m): Implemented as an alias for H, i.e., H(m).
 
 # Security Considerations {#sec-considerations}
 

--- a/poc/ed25519_rfc8032.py
+++ b/poc/ed25519_rfc8032.py
@@ -1,0 +1,179 @@
+### Extracted from RFC8032
+# https://datatracker.ietf.org/doc/html/rfc8032#section-6
+
+## First, some preliminaries that will be needed.
+
+import hashlib
+
+def sha512(s):
+    return hashlib.sha512(s).digest()
+
+# Base field Z_p
+p = 2**255 - 19
+
+def modp_inv(x):
+    return pow(x, p-2, p)
+
+# Curve constant
+d = -121665 * modp_inv(121666) % p
+
+# Group order
+q = 2**252 + 27742317777372353535851937790883648493
+
+def sha512_modq(s):
+    return int.from_bytes(sha512(s), "little") % q
+
+## Then follows functions to perform point operations.
+
+# Points are represented as tuples (X, Y, Z, T) of extended
+# coordinates, with x = X/Z, y = Y/Z, x*y = T/Z
+
+def point_add(P, Q):
+    A, B = (P[1]-P[0]) * (Q[1]-Q[0]) % p, (P[1]+P[0]) * (Q[1]+Q[0]) % p;
+    C, D = 2 * P[3] * Q[3] * d % p, 2 * P[2] * Q[2] % p;
+    E, F, G, H = B-A, D-C, D+C, B+A;
+    return (E*F, G*H, F*G, E*H);
+
+# Computes Q = s * Q
+def point_mul(s, P):
+    Q = (0, 1, 1, 0)  # Neutral element
+    while s > 0:
+        if s & 1:
+            Q = point_add(Q, P)
+        P = point_add(P, P)
+        s >>= 1
+    return Q
+
+def point_equal(P, Q):
+    # x1 / z1 == x2 / z2  <==>  x1 * z2 == x2 * z1
+    if (P[0] * Q[2] - Q[0] * P[2]) % p != 0:
+        return False
+    if (P[1] * Q[2] - Q[1] * P[2]) % p != 0:
+        return False
+    return True
+
+## Now follows functions for point compression.
+
+# Square root of -1
+modp_sqrt_m1 = pow(2, (p-1) // 4, p)
+
+# Compute corresponding x-coordinate, with low bit corresponding to
+# sign, or return None on failure
+def recover_x(y, sign):
+    if y >= p:
+        return None
+    x2 = (y*y-1) * modp_inv(d*y*y+1)
+    if x2 == 0:
+        if sign:
+            return None
+        else:
+            return 0
+
+    # Compute square root of x2
+    x = pow(x2, (p+3) // 8, p)
+    if (x*x - x2) % p != 0:
+        x = x * modp_sqrt_m1 % p
+    if (x*x - x2) % p != 0:
+        return None
+
+    if (x & 1) != sign:
+        x = p - x
+    return x
+
+# Base point
+g_y = 4 * modp_inv(5) % p
+g_x = recover_x(g_y, 0)
+G = (g_x, g_y, 1, g_x * g_y % p)
+
+def point_compress(P):
+    zinv = modp_inv(P[2])
+    x = P[0] * zinv % p
+    y = P[1] * zinv % p
+    return int.to_bytes(y | ((x & 1) << 255), 32, "little")
+
+def point_decompress(s):
+    if len(s) != 32:
+        raise Exception("Invalid input length for decompression")
+    y = int.from_bytes(s, "little")
+    sign = y >> 255
+    y &= (1 << 255) - 1
+
+    x = recover_x(y, sign)
+    if x is None:
+        return None
+    else:
+        return (x, y, 1, x*y % p)
+
+## These are functions for manipulating the private key.
+
+def secret_expand(secret):
+    if len(secret) != 32:
+        raise Exception("Bad size of private key")
+    h = sha512(secret)
+    a = int.from_bytes(h[:32], "little")
+    a &= (1 << 254) - 8
+    a |= (1 << 254)
+    return (a, h[32:])
+
+def secret_to_public(secret):
+    (a, dummy) = secret_expand(secret)
+    return point_compress(point_mul(a, G))
+
+def secret_to_public_raw(secret):
+    (a, dummy) = secret_expand(secret)
+    return point_mul(a, G)
+
+def xor(a, b):
+	res = bytes(x ^ y for x, y in zip(a, b))
+	return res
+
+## The signature function works as below.
+
+def sign_ed25519_rfc8032(secret, msg):
+    a, prefix = secret_expand(secret)
+    A = point_compress(point_mul(a, G))
+    r = sha512_modq(prefix + msg)
+    R = point_mul(r, G)
+    Rs = point_compress(R)
+    h = sha512_modq(Rs + A + msg)
+    s = (r + h * a) % q
+    return Rs + int.to_bytes(s, 32, "little")
+
+## And finally the verification function.
+
+# XXX(caw): remove when done debugging
+def to_hex(octet_string):
+    if isinstance(octet_string, str):
+        return "".join("{:02x}".format(ord(c)) for c in octet_string)
+    if isinstance(octet_string, bytes):
+        return "" + "".join("{:02x}".format(c) for c in octet_string)
+    assert isinstance(octet_string, bytearray)
+    return ''.join(format(x, '02x') for x in octet_string)
+
+def verify_ed25519_rfc8032(public, msg, signature):
+    if len(public) != 32:
+        raise Exception("Bad public key length")
+    if len(signature) != 64:
+        raise Exception("Bad signature length")
+    A = point_decompress(public)
+    if not A:
+        return False
+    Rs = signature[:32]
+    R = point_decompress(Rs)
+    if not R:
+        return False
+    s = int.from_bytes(signature[32:], "little")
+    if s >= q:
+        return False    
+    h = sha512_modq(Rs + public + msg)
+
+    sB = point_mul(s, G)
+    hA = point_mul(h, A)
+    return point_equal(sB, point_add(R, hA))
+
+if __name__ == "__main__":
+    import sys
+    public = bytearray.fromhex(sys.argv[1])
+    msg = bytearray.fromhex(sys.argv[2])
+    sig = bytearray.fromhex(sys.argv[3])
+    print(verify_ed25519_rfc8032(public, msg, sig))

--- a/poc/hash.sage
+++ b/poc/hash.sage
@@ -1,0 +1,68 @@
+#!/usr/bin/sage
+# vim: syntax=python
+
+import sys
+
+from hashlib import sha512, sha256
+
+try:
+    from sagelib.groups import GroupRistretto255, GroupEd25519, GroupP256
+except ImportError as e:
+    sys.exit("Error loading preprocessed sage files. Try running `make setup && make clean pyfiles`. Full error: " + e)
+
+_as_bytes = lambda x: x if isinstance(x, bytes) else bytes(x, "utf-8")
+
+class Hash(object):
+    def __init__(self, G, H, name):
+        self.G = G
+        self.H = H
+        self.name = name
+
+    def H1(self, m):
+        raise Exception("Not implemented")
+
+    def H2(self, m):
+        raise Exception("Not implemented")
+
+    def H3(self, m):
+        '''
+        H3(m) = H(m)
+        '''
+        hasher = self.H()
+        hasher.update(m)
+        return hasher.digest()
+
+class HashEd25519(Hash):
+    def __init__(self):
+        Hash.__init__(self, GroupEd25519(), sha512, "SHA-512")
+
+    def H1(self, m):
+        hash_input = _as_bytes("rho") + m
+        return int.from_bytes(sha512(hash_input).digest(), "little") % self.G.order()
+
+    def H2(self, m):
+        return int.from_bytes(sha512(m).digest(), "little") % self.G.order()
+
+class HashRistretto255(Hash):
+    def __init__(self):
+        Hash.__init__(self, GroupRistretto255(), sha512, "SHA-512")
+
+    def H1(self, m):
+        hash_input = _as_bytes("FROST-RISTRETTO255-SHA512 rho") + m
+        return int.from_bytes(sha512(hash_input).digest(), "little") % self.G.order()
+
+    def H2(self, m):
+        hash_input = _as_bytes("FROST-RISTRETTO255-SHA512 chal") + m
+        return int.from_bytes(sha512(hash_input).digest(), "little") % self.G.order()
+
+class HashP256(Hash):
+    def __init__(self):
+        Hash.__init__(self, GroupP256(), sha256, "SHA-256")
+
+    def H1(self, m):
+        dst = _as_bytes("FROST-P256-SHA256 rho")
+        return self.G.hash_to_scalar(m, dst=dst)
+
+    def H2(self, m):
+        dst = _as_bytes("FROST-P256-SHA256 chal")
+        return self.G.hash_to_scalar(m, dst=dst)

--- a/poc/hash.sage
+++ b/poc/hash.sage
@@ -25,12 +25,7 @@ class Hash(object):
         raise Exception("Not implemented")
 
     def H3(self, m):
-        '''
-        H3(m) = H(m)
-        '''
-        hasher = self.H()
-        hasher.update(m)
-        return hasher.digest()
+        raise Exception("Not implemented")
 
 class HashEd25519(Hash):
     def __init__(self):
@@ -42,6 +37,11 @@ class HashEd25519(Hash):
 
     def H2(self, m):
         return int.from_bytes(sha512(m).digest(), "little") % self.G.order()
+
+    def H3(self, m):
+        hasher = self.H()
+        hasher.update(m)
+        return hasher.digest()
 
 class HashRistretto255(Hash):
     def __init__(self):
@@ -55,6 +55,12 @@ class HashRistretto255(Hash):
         hash_input = _as_bytes("FROST-RISTRETTO255-SHA512 chal") + m
         return int.from_bytes(sha512(hash_input).digest(), "little") % self.G.order()
 
+    def H3(self, m):
+        hasher = self.H()
+        hasher.update(_as_bytes("FROST-RISTRETTO255-SHA512 digest"))
+        hasher.update(m)
+        return hasher.digest()
+
 class HashP256(Hash):
     def __init__(self):
         Hash.__init__(self, GroupP256(), sha256, "SHA-256")
@@ -66,3 +72,9 @@ class HashP256(Hash):
     def H2(self, m):
         dst = _as_bytes("FROST-P256-SHA256 chal")
         return self.G.hash_to_scalar(m, dst=dst)
+
+    def H3(self, m):
+        hasher = self.H()
+        hasher.update(_as_bytes("FROST-P256-SHA256 digest"))
+        hasher.update(m)
+        return hasher.digest()


### PR DESCRIPTION
This demonstrates RFC8032 compliance (for vanilla Ed25519, not the ctx or ph variants). To do so, it creates a signature using the reference implementation, encodes the signature and public key as RFC8032 expects, and then calls the signature verification routine [from the RFC](https://datatracker.ietf.org/doc/html/rfc8032#section-6).

This change raises a couple of questions (to me), including:
1. The pre-hash step introduced in [this PR](https://github.com/cfrg/draft-irtf-cfrg-frost/pull/46), to address [this issue](https://github.com/cfrg/draft-irtf-cfrg-frost/issues/43), meant that the vanilla ed25519 interop wouldn't work. (Vanilla ed25519 doesn't pre-hash the message when computing the challenge.) I think we got the change in #46 wrong. [The audit](https://github.com/ZcashFoundation/redjubjub/blob/main/zcash-frost-audit-report-20210323.pdf) only recommends this pre-hashing step when computing the blinding factor, not when computing the challenge, so I _think_ we could revert the pre-hashing step for the challenge.
1. Do we want to specify a pile of different variants like RFC8032 did, including "vanilla" mode (Ed25519), pre-hash (ph) mode (Ed25519ph), and context-specific (ctx) mode (Ed25519ctx)? It seems like a lot of complexity to do everything, and to be honest I'm not sure what variant is most useful in practice. Does anyone else know?
1. What is our API abstraction boundary? EdDSA uses byte strings everywhere, including signing and verifying keys, as well as signatures. Currently, we operate on "internal" types, e.g., scalars and elements for signing and verifying keys, respectively, and our signatures are (element, scalar) tuples. Should we adopt a higher layer of abstraction?
1. Signature verification in this change was updated to match the logic in RFC8032. That is, rather than re-derive the group commitment and check for equality, check that the relation holds `[8][S]B = [8]R + [8][k]A'`.
1. How do we want to handle domain separation for H1 and H2 for ciphersuites that target groups outside of RFC8032? 

Starting as a draft for now until we figure out what to do about (1), since I commented out the pre-hashing step in the code. I don't think we need to block on any of the remaining questions.

cc @veorq in case he has thoughts on (1)