### PR TITLE
Add Schnorr to the title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Two-Round Threshold Signatures with FROST
+# Two-Round Threshold Schnorr Signatures with FROST
 
-This is the working area for the individual Internet-Draft, "Two-Round Threshold Signatures with FROST".
+This is the working area for the individual Internet-Draft, "Two-Round Threshold Schnorr Signatures with FROST".
 
 * [Editor's Copy](https://cfrg.github.io/draft-irtf-cfrg-frost/#go.draft-irtf-cfrg-frost.html)
 * [Datatracker Page](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost)

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -1,5 +1,5 @@
 ---
-title: "Two-Round Threshold Signatures with FROST"
+title: "Two-Round Threshold Schnorr Signatures with FROST"
 abbrev: "FROST"
 docname: draft-irtf-cfrg-frost-latest
 category: info


### PR DESCRIPTION
So as to distinguish it from solutions for RSA or ECDSA signatures, which can be dealt with separately.