### PR TITLE
Breakout commitment share generation to an aggregate subroutine

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -656,7 +656,7 @@ parameters, to check that the signature share is correct using the following pro
     # Compute the challenge
     challenge = compute_challenge(group_commitment, group_public_key, msg)
 
-    # Compute Lagrangian coefficient
+    # Compute Lagrange coefficient
     lambda_i = derive_lagrange_coefficient(index, participant_list)
 
     # Compute relation values

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -674,7 +674,7 @@ signature.
 
 ~~~
   Inputs:
-  - group_commitment, the group commitment.
+  - group_commitment, the group commitment returned by compute_group_commitment
   - sig_shares, a set of signature shares z_i for each signer, of length NUM_SIGNERS,
   where THRESHOLD_LIMIT <= NUM_SIGNERS <= MAX_SIGNERS.
 

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -590,7 +590,7 @@ procedure to produce its own signature share.
     # Compute the group commitment
     group_commitment = compute_group_commitment(commitment_list, binding_factor)
 
-    # Compute Lagrangian coefficient
+    # Compute Lagrange coefficient
     lambda_i = derive_lagrange_coefficient(index, participant_list)
 
     # Compute the per-message challenge

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -628,7 +628,7 @@ parameters, to check that the signature share is correct using the following pro
     in round one from the ith signer.
   - sig_share_i, a Scalar value indicating the signature share as produced in round two from the ith signer.
   - commitment_list = [(j, hiding_nonce_commitment_j, binding_nonce_commitment_j), ...], a list of commitments
-    issued by each signer, where each element in the list indicates the signer index j and their
+    issued in Round 1 by each signer, where each element in the list indicates the signer index j and their
     two commitment Element values (hiding_nonce_commitment_j, binding_nonce_commitment_j).
     This list MUST be sorted in ascending order by signer index.
   - participant_list, a set containing identifiers for each signer, similarly of length

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -347,10 +347,10 @@ interpolation, defined as follows.
     return f_zero
 ~~~
 
-## Encoding Operations {#dep-encoding}
+## Commitment List Encoding {#dep-encoding}
 
-This section describes various helper functions used for encoding data
-structures into values that can be processed with hash functions.
+This section describes the subroutine used for encoding a list of signer
+commitments into a bytestring that is used in the FROST protocol.
 
 ~~~
   Inputs:
@@ -369,6 +369,68 @@ structures into values that can be processed with hash functions.
                            G.SerializeElement(binding_nonce_commitment)
       encoded_group_commitment = encoded_group_commitment || encoded_commitment
     return encoded_group_commitment
+~~~
+
+## Binding Factor Computation {#dep-binding-factor}
+
+This section describes the subroutine for computing the binding factor based
+on the signer commitment list and message to be signed.
+
+~~~
+  Inputs:
+  - encoded_commitment_list, an encoded commitment list (as computed
+    by encode_group_commitment_list)
+  - msg, the message to be signed (sent by the Coordinator).
+
+  Outputs: binding_factor, a Scalar representing the binding factor
+
+  def compute_binding_factor(encoded_commitment_list, msg):
+    msg_hash = H3(msg)
+    rho_input = encoded_commitment_list || msg_hash
+    binding_factor = H1(rho_input)
+    return binding_factor
+~~~
+
+## Group Commitment Computation {#dep-group-commit}
+
+This section describes the subroutine for creating the group commitment
+from a commitment list.
+
+~~~
+  Inputs:
+  - commitment_list = [(i, hiding_nonce_commitment_i, binding_nonce_commitment_i), ...], a list of
+    commitments issued by each signer, where each element in the list indicates the signer index i and their
+    two commitment Element values (hiding_nonce_commitment_i, binding_nonce_commitment_i).
+    This list MUST be sorted in ascending order by signer index.
+  - binding_factor, a Scalar
+
+  Outputs: An Element representing the group commitment
+
+  def compute_group_commitment(commitment_list, binding_factor):
+    group_commitment = G.Identity()
+    for (_, hiding_nonce_commitment, binding_nonce_commitment) in commitment_list:
+      group_commitment = group_commitment + (hiding_nonce_commitment + (binding_nonce_commitment * binding_factor))
+    return group_commitment
+~~~
+
+## Signature Challenge Computation {#dep-sig-challenge}
+
+This section describes the subroutine for creating the per-message challenge.
+
+~~~
+  Inputs:
+  - group_commitment, an Element representing the group commitment
+  - group_public_key, public key corresponding to the signer secret key share.
+  - msg, the message to be signed (sent by the Coordinator).
+
+  Outputs: a challenge Scalar value
+
+  def compute_challenge(group_commitment, group_public_key, msg):
+    group_comm_enc = G.SerializeElement(group_commitment)
+    group_public_key_enc = G.SerializeElement(group_public_key)
+    challenge_input = group_comm_enc || group_public_key_enc || msg
+    challenge = H2(challenge_input)
+    return challenge
 ~~~
 
 # Two-Round FROST {#frost-spec}
@@ -508,46 +570,37 @@ procedure to produce its own signature share.
   - sk_i, Signer secret key share.
   - group_public_key, public key corresponding to the signer secret key share.
   - nonce_i, pair of Scalar values (hiding_nonce, binding_nonce) generated in round one.
-  - comm_i, pair of Element values (hiding_nonce_commitment, binding_nonce_commitment) generated in round one.
   - msg, the message to be signed (sent by the Coordinator).
-  - commitment_list = [(j, hiding_nonce_commitment_j, binding_nonce_commitment_j), ...], a list of commitments issued by each signer,
-    where each element in the list indicates the signer index j and their
-    two commitment Element values (hiding_nonce_commitment_j, binding_nonce_commitment_j). This list MUST be sorted in ascending order
-    by signer index.
+  - commitment_list = [(j, hiding_nonce_commitment_j, binding_nonce_commitment_j), ...], a
+    list of commitments issued by each signer, where each element in the list indicates the signer index j and their
+    two commitment Element values (hiding_nonce_commitment_j, binding_nonce_commitment_j).
+    This list MUST be sorted in ascending order by signer index.
   - participant_list, a set containing identifiers for each signer, similarly of length
     NUM_SIGNERS (sent by the Coordinator).
 
-  Outputs: a signature share sig_share and commitment share comm_share, which
-           are Scalar and Element values respectively.
+  Outputs: a Scalar value representing the signature share
 
-  def sign(index, sk_i, group_public_key, nonce_i, comm_i, msg, commitment_list, participant_list):
-    # Compute the binding factor
+  def sign(index, sk_i, group_public_key, nonce_i, msg, commitment_list, participant_list):
+    # Encode the commitment list
     encoded_commitments = encode_group_commitment_list(commitment_list)
-    msg_hash = H3(msg)
-    binding_factor = H1(encoded_commitments || msg_hash)
+
+    # Compute the binding factor
+    binding_factor = compute_binding_factor(encoded_commitments, msg)
 
     # Compute the group commitment
-    R = G.Identity()
-    for (_, hiding_nonce_commitment, binding_nonce_commitment) in commitment_list:
-      R = R + (hiding_nonce_commitment + (binding_nonce_commitment * binding_factor))
+    group_commitment = compute_group_commitment(commitment_list, binding_factor)
 
+    # Compute Lagrangian coefficient
     lambda_i = derive_lagrange_coefficient(index, participant_list)
 
     # Compute the per-message challenge
-    group_comm_enc = G.SerializeElement(R)
-    group_public_key_enc = G.SerializeElement(group_public_key)
-    challenge_input = group_comm_enc || group_public_key_enc || msg_hash
-    c = H2(challenge_input)
+    challenge = compute_challenge(group_commitment, group_public_key, msg)
 
     # Compute the signature share
     (hiding_nonce, binding_nonce) = nonce_i
-    sig_share = hiding_nonce + (binding_nonce * binding_factor) + (lambda_i * sk_i * c)
+    sig_share = hiding_nonce + (binding_nonce * binding_factor) + (lambda_i * sk_i * challenge)
 
-    # Compute the commitment share
-    (hiding_nonce_commitment, binding_nonce_commitment) = comm_i
-    comm_share = hiding_nonce_commitment + (binding_nonce_commitment * binding_factor)
-
-    return sig_share, comm_share
+    return sig_share
 ~~~
 
 The output of this procedure is a signature share and group commitment share.
@@ -559,55 +612,78 @@ signature and commitment shares using DeserializeElement for each. If validation
 fails, the Coordinator MUST abort the protocol. If validation succeeds, the
 Coordinator then verifies the set of signature shares using the following procedure.
 
-<!-- the inputs to this function need to be revisited, things can probably be made simpler -->
+## Signature Share Verification and Aggregation {#frost-aggregation}
+
+After signers perform round two and send their signature shares to the Coordinator,
+the Coordinator verifies each signature share for correctness. In particular,
+for each signer, the Coordinator uses commitment pairs generated during round
+one and the signature share generated during round two, along with other group
+parameters, to check that the signature share is correct using the following procedure.
+
 ~~~
   Inputs:
-  - group_comm, the group commitment
+  - index, Index `i` of the signer. Note index will never equal `0`.
+  - public_key_share_i, the public key for the ith signer, where public_key_share = G.ScalarBaseMult(s[i])
+  - comm_i, pair of Element values (hiding_nonce_commitment, binding_nonce_commitment) generated
+    in round one from the ith signer.
+  - sig_share_i, a Scalar value indicating the signature share as produced in round two from the ith signer.
+  - commitment_list = [(j, hiding_nonce_commitment_j, binding_nonce_commitment_j), ...], a list of commitments
+    issued by each signer, where each element in the list indicates the signer index j and their
+    two commitment Element values (hiding_nonce_commitment_j, binding_nonce_commitment_j).
+    This list MUST be sorted in ascending order by signer index.
   - participant_list, a set containing identifiers for each signer, similarly of length
     NUM_SIGNERS (sent by the Coordinator).
-  - index, Index `i` of the signer. Note index will never equal `0`.
   - group_public_key, the public key for the group
-  - public_key_share, the public key for the ith signer, where public_key_share = G.ScalarBaseMult(s[i])
-  - sig_share, the signature share for the ith signer, computed from the signer
-  - comm_share, the commitment for the ith signer, computed from the signer
   - msg, the message to be signed
 
-  Outputs: 1 if the signature share is valid, and 0 otherwise.
+  Outputs: True if the signature share is valid, and False otherwise.
 
-  def verify_signature_share(group_comm, participant_list, index, group_public_key, public_key_share, sig_share, comm_share, msg):
-    group_comm_enc = G.SerializeElement(group_comm)
-    group_public_key_enc = G.SerializeElement(group_public_key)
-    challenge_input = group_comm_enc || group_public_key_enc || msg
-    c = H2(challenge_input)
+  def verify_signature_share(index, public_key_share_i, comm_i, sig_share_i, commitment_list,
+                             participant_list, group_public_key, msg):
+    # Encode the commitment list
+    encoded_commitments = encode_group_commitment_list(commitment_list)
 
-    l = G.ScalarBaseMult(sig_share)
+    # Compute the binding factor
+    binding_factor = compute_binding_factor(encoded_commitments, msg)
 
+    # Compute the group commitment
+    group_commitment = compute_group_commitment(commitment_list, binding_factor)
+
+    # Compute the commitment share
+    (hiding_nonce_commitment, binding_nonce_commitment) = comm_i
+    comm_share = hiding_nonce_commitment + (binding_nonce_commitment * binding_factor)
+
+    # Compute the challenge
+    challenge = compute_challenge(group_commitment, group_public_key, msg)
+
+    # Compute Lagrangian coefficient
     lambda_i = derive_lagrange_coefficient(index, participant_list)
-    r = comm_share + (public_key_share * c * lambda_i)
+
+    # Compute relation values
+    l = G.ScalarBaseMult(sig_share_i)
+    r = comm_share + (public_key_share * challenge * lambda_i)
 
     return l == r
 ~~~
 
-## Signature Share Aggregation {#frost-aggregation}
-
-After signers perform round two and send their signature shares to the Coordinator,
-the Coordinator performs the `aggregate` operation and publishes the resulting
-signature. As described in {{frost-round-two}}, the Coordinator MUST validate each
-Signer's signature share before aggregation.
+If any signature share fails to verify, i.e., if verify_signature_share returns False for
+any signer share, the Coordinator MUST abort the protocol. Otherwise, if all signer shares
+are valid, the Coordinator performs the `aggregate` operation and publishes the resulting
+signature.
 
 ~~~
   Inputs:
-  - R: the group commitment.
-  - sig_shares: a set of signature shares z_i for each signer, of length NUM_SIGNERS,
+  - group_commitment, the group commitment.
+  - sig_shares, a set of signature shares z_i for each signer, of length NUM_SIGNERS,
   where THRESHOLD_LIMIT <= NUM_SIGNERS <= MAX_SIGNERS.
 
   Outputs: (R, z), a Schnorr signature consisting of an Element and Scalar value.
 
-  def frost_aggregate(R, sig_shares):
+  def frost_aggregate(group_commitment, sig_shares):
     z = 0
     for z_i in sig_shares:
       z = z + z_i
-    return (R, z)
+    return (group_commitment, z)
 ~~~
 
 The output signature (R, z) from the aggregation step MUST be encoded as follows:

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -618,7 +618,7 @@ After signers perform round two and send their signature shares to the Coordinat
 the Coordinator verifies each signature share for correctness. In particular,
 for each signer, the Coordinator uses commitment pairs generated during round
 one and the signature share generated during round two, along with other group
-parameters, to check that the signature share is correct using the following procedure.
+parameters, to check that the signature share is valid using the following procedure.
 
 ~~~
   Inputs:

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -572,7 +572,7 @@ procedure to produce its own signature share.
   - nonce_i, pair of Scalar values (hiding_nonce, binding_nonce) generated in round one.
   - msg, the message to be signed (sent by the Coordinator).
   - commitment_list = [(j, hiding_nonce_commitment_j, binding_nonce_commitment_j), ...], a
-    list of commitments issued by each signer, where each element in the list indicates the signer index j and their
+    list of commitments issued in Round 1 by each signer, where each element in the list indicates the signer index j and their
     two commitment Element values (hiding_nonce_commitment_j, binding_nonce_commitment_j).
     This list MUST be sorted in ascending order by signer index.
   - participant_list, a set containing identifiers for each signer, similarly of length

--- a/poc/ed25519_rfc8032.py
+++ b/poc/ed25519_rfc8032.py
@@ -141,15 +141,6 @@ def sign_ed25519_rfc8032(secret, msg):
 
 ## And finally the verification function.
 
-# XXX(caw): remove when done debugging
-def to_hex(octet_string):
-    if isinstance(octet_string, str):
-        return "".join("{:02x}".format(ord(c)) for c in octet_string)
-    if isinstance(octet_string, bytes):
-        return "" + "".join("{:02x}".format(c) for c in octet_string)
-    assert isinstance(octet_string, bytearray)
-    return ''.join(format(x, '02x') for x in octet_string)
-
 def verify_ed25519_rfc8032(public, msg, signature):
     if len(public) != 32:
         raise Exception("Bad public key length")

--- a/poc/test-vectors.json
+++ b/poc/test-vectors.json
@@ -47,12 +47,10 @@
       "participants": "1,2",
       "signers": {
         "1": {
-          "sig_share": "f8bbaf924e1c90e11dec1eb679194aade084f92fbf52fdd436ba0a07f71ab708",
-          "group_commitment_share": "11bb9777aa393b92e814e415039adf62687a0be543c2322d817e4934bc5a7cf2"
+          "sig_share": "f8bbaf924e1c90e11dec1eb679194aade084f92fbf52fdd436ba0a07f71ab708"
         },
         "2": {
-          "sig_share": "80f589405714ca0e6adc87c2c0186a0ae4d6e352f7b248b23149a5dcd3fe4704",
-          "group_commitment_share": "4af85179d17ed031b767ab579e59c7018dac09ae400b1700623d0af1129a9c55"
+          "sig_share": "80f589405714ca0e6adc87c2c0186a0ae4d6e352f7b248b23149a5dcd3fe4704"
         }
       }
     },
@@ -108,12 +106,10 @@
       "participants": "1,2",
       "signers": {
         "1": {
-          "sig_share": "ad41cd3320c82edd20c344769bd7b250105d9d0516109b7f774c297faaf8b3b6065b19bbae2afb6c34cce460b40e15655fb8ad0bcc26e21e00",
-          "group_commitment_share": "086d4d2ff2555fab65afc8eb473cc708f37cdb9c5de74d8e12a1a9d1a086a8914175e4db77e5d281f10441913aa680fedb207c954afdd88380"
+          "sig_share": "ad41cd3320c82edd20c344769bd7b250105d9d0516109b7f774c297faaf8b3b6065b19bbae2afb6c34cce460b40e15655fb8ad0bcc26e21e00"
         },
         "2": {
-          "sig_share": "5dcc0aec7d0a71eddd5ba2dd0f185ba7990bcd39b6fc0e4b0470c356ed0deb736d7f2652e87e932a0c176cc4bc5ba0ef756cc62081e4f51900",
-          "group_commitment_share": "7e91f66097b6450c52c89c14400a506ee1d37f5e52a8d4c3fc9733c23d0b27cd6cfce55a8aee692262e5815be341e8d0b9d240a9630c9f0600"
+          "sig_share": "5dcc0aec7d0a71eddd5ba2dd0f185ba7990bcd39b6fc0e4b0470c356ed0deb736d7f2652e87e932a0c176cc4bc5ba0ef756cc62081e4f51900"
         }
       }
     },
@@ -169,12 +165,10 @@
       "participants": "1,2",
       "signers": {
         "1": {
-          "sig_share": "ec6b075f17c5670e80b1fda8f6de1cfe3c79db06a852f8d5650fb71eaad69501",
-          "group_commitment_share": "bc7e792fce347a15d547935652377c406cc721965c58d3003dbd947a6dfddc0c"
+          "sig_share": "ec6b075f17c5670e80b1fda8f6de1cfe3c79db06a852f8d5650fb71eaad69501"
         },
         "2": {
-          "sig_share": "87ceccc477069aa9b751b307f25955daaf943a3abc51f214a114781de0f58e03",
-          "group_commitment_share": "92c4f352ec392ba779271dc2ed09cda37f38d8c283747d4a85b4c9ce7289cb07"
+          "sig_share": "87ceccc477069aa9b751b307f25955daaf943a3abc51f214a114781de0f58e03"
         }
       }
     },
@@ -230,12 +224,10 @@
       "participants": "1,2",
       "signers": {
         "1": {
-          "sig_share": "120a8ef8a5936444d8087cb10df5648629895e94582720760a10c8c217e3417b",
-          "group_commitment_share": "0314cc3c03885953b3a15482d0ef4716eba9aca439fa541a37489a146dd383d07e"
+          "sig_share": "120a8ef8a5936444d8087cb10df5648629895e94582720760a10c8c217e3417b"
         },
         "2": {
-          "sig_share": "2a7ff42d849f1bcc0e5f75d5810900a3e8f68ab717ff10d7a6da89f8bb0c16aa",
-          "group_commitment_share": "034f4516676fe414883397fc5e150375c9937b3b773c9ac57a11b2b6574e6bf452"
+          "sig_share": "2a7ff42d849f1bcc0e5f75d5810900a3e8f68ab717ff10d7a6da89f8bb0c16aa"
         }
       }
     },


### PR DESCRIPTION
And remove R_share as an output from round two. This also decomposes `sign` and `verify_signature_share` into smaller, reusable subroutines. 