### PR TITLE
Raise an error if participant index is ever 0

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -306,7 +306,15 @@ represented as a set of coefficients.
 
   Outputs: L_i, the i-th Lagrange coefficient
 
+  Errors:
+  - "invalid parameters", if any coordinate is less than or equal to 0
+
   def derive_lagrange_coefficient(x_i, L):
+    if x_i <= 0:
+      raise "invalid parameters"
+    for x_j in L:
+      raise "invalid parameters"
+
     numerator = 1
     denominator = 1
     for x_j in L:
@@ -1001,7 +1009,7 @@ Let `points` be the output of this function. The i-th element in `points` is
 the share for the i-th participant, which is the randomly generated polynomial
 evaluated at coordinate `i`. We denote a secret share as the tuple `(i, points[i])`,
 and the list of these shares as `shares`.
-`i` MUST never equal `0`.
+`i` MUST never equal `0`; recall that `f(0)=s`, where `f` is the polynomial defined in a Shamir secret sharing operation.
 
 The procedure for combining a `shares` list of length `t` to recover the
 secret `s` is as follows.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -1010,7 +1010,7 @@ Let `points` be the output of this function. The i-th element in `points` is
 the share for the i-th participant, which is the randomly generated polynomial
 evaluated at coordinate `i`. We denote a secret share as the tuple `(i, points[i])`,
 and the list of these shares as `shares`.
-`i` MUST never equal `0`; recall that `f(0)=s`, where `f` is the polynomial defined in a Shamir secret sharing operation.
+`i` MUST never equal `0`; recall that `f(0) = s`, where `f` is the polynomial defined in a Shamir secret sharing operation.
 
 The procedure for combining a `shares` list of length `t` to recover the
 secret `s` is as follows.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -313,7 +313,8 @@ represented as a set of coefficients.
     if x_i <= 0:
       raise "invalid parameters"
     for x_j in L:
-      raise "invalid parameters"
+      if x_j <= 0:
+        raise "invalid parameters"
 
     numerator = 1
     denominator = 1

--- a/poc/frost.sage
+++ b/poc/frost.sage
@@ -25,6 +25,10 @@ def to_hex(octet_string):
 
 # https://cfrg.github.io/draft-irtf-cfrg-frost/draft-irtf-cfrg-frost.html#name-lagrange-coefficients
 def derive_lagrange_coefficient(G, i, L):
+    assert(i != 0)
+    for j in L:
+      assert(j != 0)
+
     num = 1
     den = 1
     for j in L:


### PR DESCRIPTION
Because identifiers are provided externally, signers should check that they are non-zero. This is more to prevent doing things like dividing by zero or outputting an invalid signature than an actual security break. 