### PR TITLE
Update group info, consistent notation for secret keys

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -471,12 +471,16 @@ more information.
 In FROST, all signers are assumed to have the (public) group state that we refer to as "group info"
 below, and their corresponding signing key shares.
 
-In particular, FROST assumes that the coordinator and each signing participant `P_i` knows the following:
+In particular, FROST assumes that the coordinator and each signing participant `P_i` knows the following
+group info:
 
 - Group public key, denoted `PK = G.ScalarMultBase(s)`, corresponding to the group secret key `s`.
 `PK` is an output from the group's key generation protocol, such as `trusted_dealer_keygen`or a DKG.
 - Public keys for each signer, denoted `PK_i = G.ScalarMultBase(sk_i)`, which are similarly
 outputs from the group's key generation protocol.
+
+And that each participant with identifier `i` additionally knows the following:
+
 - Participant `i`s signing key `sk_i`, which is the i-th secret share of `s`.
 
 The exact key generation mechanism is out of scope for this specification. In general,

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -1095,7 +1095,6 @@ The procedure for verification of a participant's share is as follows.
   vss_verify(share_i, C):
 
   Inputs:
-  - A participant's index `i`
   - share_i: A tuple of the form (i, sk_i), where i indicates the participant
   identifier, and sk_i the participant's secret key, where sk_i is a secret share of
   the constant term of f.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -481,7 +481,7 @@ outputs from the group's key generation protocol.
 
 And that each participant with identifier `i` additionally knows the following:
 
-- Participant `i`s signing key `sk_i`, which is the i-th secret share of `s`.
+- Participant `i`s signing key share `sk_i`, which is the i-th secret share of `s`.
 
 The exact key generation mechanism is out of scope for this specification. In general,
 key generation is a protocol that outputs (1) a shared, group public key PK owned


### PR DESCRIPTION
Addresses  #112 and #115, and also makes the notation for participant secret keys consistent.