### PR TITLE
Update group commitment derivation to have a single scalarmul

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -448,9 +448,8 @@ from a commitment list.
     group_hiding_commitment = G.Identity()
     group_binding_commitment = G.Identity()
 
-    for (_, hiding_nonce_commitment, _) in commitment_list:
+    for (_, hiding_nonce_commitment, binding_nonce_commitment) in commitment_list:
       group_hiding_commitment = group_hiding_commitment + hiding_nonce_commitment 
-    for (_, _, binding_nonce_commitment) in commitment_list:
       group_binding_commitment = group_binding_commitment + binding_nonce_commitment
     return (group_hiding_commitment + group_binding_commitment * binding_factor) 
 ~~~

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -445,10 +445,14 @@ from a commitment list.
   Outputs: An `Element` in `G` representing the group commitment
 
   def compute_group_commitment(commitment_list, binding_factor):
-    group_commitment = G.Identity()
-    for (_, hiding_nonce_commitment, binding_nonce_commitment) in commitment_list:
-      group_commitment = group_commitment + (hiding_nonce_commitment + (binding_nonce_commitment * binding_factor))
-    return group_commitment
+    group_hiding_commitment = G.Identity()
+    group_binding_commitment = G.Identity()
+
+    for (_, hiding_nonce_commitment, _) in commitment_list:
+      group_hiding_commitment = group_hiding_commitment + hiding_nonce_commitment 
+    for (_, _, binding_nonce_commitment) in commitment_list:
+      group_binding_commitment = group_binding_commitment + binding_nonce_commitment
+    return (group_hiding_commitment + group_binding_commitment * binding_factor) 
 ~~~
 
 ## Signature Challenge Computation {#dep-sig-challenge}

--- a/poc/frost.sage
+++ b/poc/frost.sage
@@ -144,10 +144,12 @@ def compute_binding_factor(H, encoded_commitments, msg):
     return binding_factor, rho_input
 
 def compute_group_commitment(G, commitment_list, binding_factor):
-    group_commitment = G.identity()
+    group_hiding_commitment = G.identity()
+    group_binding_commitment = G.identity()
     for (_, D_i, E_i) in commitment_list:
-        group_commitment = group_commitment + (D_i + (E_i * binding_factor))
-    return group_commitment
+        group_hiding_commitment = group_hiding_commitment + D_i 
+        group_binding_commitment = group_binding_commitment + E_i 
+    return group_hiding_commitment + group_binding_commitment * binding_factor 
 
 def compute_challenge(H, group_commitment, group_public_key, msg):
     group_comm_enc = G.serialize(group_commitment)


### PR DESCRIPTION
This fixes the derivation of the group commitment so that it requires a single scalar multiplication, as opposed to `t`