### PR TITLE
Assert that the network channel used for signing should be authenticated

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -560,7 +560,7 @@ are described in {{frost-round-two}}. The final Aggregation step is described in
 FROST assumes reliable message delivery between the Coordinator and signing participants in
 order for the protocol to complete. An attacker masquerading as another participant will result only in an invalid signature; see {{sec-considerations}}.
 However, in order to identify any participant which has misbehaved (resulting in the protocol aborting) to take actions such as excluding them from future signing operations,
-we assume that the network channel is authenticated (but not private).
+we assume that the network channel is additionally authenticated; confidentiality is not required.
 
 ## Round One - Commitment {#frost-round-one}
 

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -559,8 +559,8 @@ are described in {{frost-round-two}}. The final Aggregation step is described in
 
 FROST assumes reliable message delivery between the Coordinator and signing participants in
 order for the protocol to complete. An attacker masquerading as another participant will result only in an invalid signature; see {{sec-considerations}}.
-However, in order to identify which participant misbehaved to take actions such as excluding them from future signing operations
-or to investigate the failure, we assume that the network channel is authenticated (but not private).
+However, in order to identify any participant which has misbehaved (resulting in the protocol aborting) to take actions such as excluding them from future signing operations,
+we assume that the network channel is authenticated (but not private).
 
 ## Round One - Commitment {#frost-round-one}
 

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -555,9 +555,12 @@ Details for round one are described in {{frost-round-one}}, and details for roun
 are described in {{frost-round-two}}. The final Aggregation step is described in
 {{frost-aggregation}}.
 
+## Network Channel Assumptions
+
 FROST assumes reliable message delivery between the Coordinator and signing participants in
-order for the protocol to complete. An attacker masquerading as another participant will
-result only in an invalid signature; see {{sec-considerations}}.
+order for the protocol to complete. An attacker masquerading as another participant will result only in an invalid signature; see {{sec-considerations}}.
+However, in order to identify which participant misbehaved to take actions such as excluding them from future signing operations
+or to investigate the failure, we assume that the network channel is authenticated (but not private).
 
 ## Round One - Commitment {#frost-round-one}
 

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -555,7 +555,6 @@ Details for round one are described in {{frost-round-one}}, and details for roun
 are described in {{frost-round-two}}. The final Aggregation step is described in
 {{frost-aggregation}}.
 
-## Network Channel Assumptions
 
 FROST assumes reliable message delivery between the Coordinator and signing participants in
 order for the protocol to complete. An attacker masquerading as another participant will result only in an invalid signature; see {{sec-considerations}}.


### PR DESCRIPTION
While fewer than `t` misbehaving players cannot do anything other than cause a DOS attack during signing, implementations should be able to identify which players misbehaved. This asserts that the network channel used during signing should be authenticated and reliable, but is allowed to be public. 