### PR TITLE
Require SerializeElement to fail if the Element is the identity element; Add specific Serialize functions for public keys

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -856,8 +856,7 @@ The value of the contextString parameter is empty.
 - Group: edwards448 {{!RFC8032}}
   - Cofactor (`h`): 4
   - SerializeNonIdentityElement: Implemented as specified in {{!RFC8032, Section 5.2.2}}.
-    Additionally, this function validates that the resulting element is not the group
-    identity element.
+    This function raises a SerializeError exception if the input is the identity element.
   - DeserializeNonIdentityElement: Implemented as specified in {{!RFC8032, Section 5.2.3}}.
     Additionally, this function validates that the resulting element is not the group
     identity element.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -832,6 +832,7 @@ The value of the contextString parameter is "FROST-RISTRETTO255-SHA512".
 - Group: ristretto255 {{!RISTRETTO=I-D.irtf-cfrg-ristretto255-decaf448}}
   - Cofactor (`h`): 1
   - SerializeNonIdentityElement: Implemented using the 'Encode' function from {{!RISTRETTO}}.
+     This function raises a SerializeError exception if the input is the identity element.
   - DeserializeNonIdentityElement: Implemented using the 'Decode' function from {{!RISTRETTO}}.
   - SerializeElement: Implemented using the 'Encode' function from {{!RISTRETTO}}.
   - DeserializeElement: Implemented using the 'Decode' function from {{!RISTRETTO}}.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -889,8 +889,7 @@ The value of the contextString parameter is "FROST-P256-SHA256".
   - Cofactor (`h`): 1
   - SerializeNonIdentityElement: Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
     method according to {{SECG}}.
-    Additionally, this function validates that the resulting element is not the group
-    identity element.
+    This function raises a SerializeError exception if the input is the identity element.
   - DeserializeNonIdentityElement: Implemented by attempting to deserialize a public key using
     the compressed Octet-String-to-Elliptic-Curve-Point method according to {{SECG}},
     and then performs partial public-key validation as defined in section 5.6.2.3.4 of

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -200,12 +200,10 @@ We now detail a number of member functions that can be invoked on `G`.
 - SerializeElement(A): Maps an `Element` `A` to a unique byte array `buf` of fixed length `Ne`,
   and fails if the input is not a valid byte representation of an element of
   the group. This function can raise a SerializeError if serialization fails.
-  Optionally, a SerializeError MAY be raised if `A` is the identity element of the group.
   See {{ciphersuites}} for group-specific input validation steps. 
 - DeserializeElement(buf): Attempts to map a byte array `buf` to an `Element` `A`,
   and fails if the input is not a valid byte representation of an element of
   the group. This function can raise a DeserializeError if deserialization fails.
-  Optionally, a SerializeError MAY be raised if `A` is the identity element of the group.
   See {{ciphersuites}} for group-specific input validation steps.
 - SerializeNonIdentityElement(A): Maps an `Element` `A` to a unique byte array `buf` of fixed length `Ne`,
   and fails if the input is not a valid byte representation of an element of
@@ -252,8 +250,8 @@ Implementations may wish to sample public key material from a distribution that 
 or rejects the identity element of the underlying group. To scope this choice to only public 
 key material, we define the following two alias functions. See {{dep-pog}} for more information.
 
-- SerializePublicKey(PK): Alias for SerializeElement(A), as defined in {{dep-pog}}. 
-- DeserializePublicKey(buf): Alias for DeserializeElement(buf), as defined in {{dep-pog}}. 
+- SerializePublicKey(PK): Alias for *either* SerializeElement(A) or SerializeNonIdentity(A) as required by the application.
+- DeserializePublicKey(buf): Alias for *either* DeserializeElement(buf) or DeserializeNonIdentity(buf), as required by the application. 
 
 ## Schnorr Signature Operations {#dep-schnorr}
 

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -197,10 +197,7 @@ We now detail a number of member functions that can be invoked on `G`.
 - Identity(): Outputs the identity `Element` of the group (i.e. `I`).
 - RandomScalar(): Outputs a random `Scalar` element in GF(p).
 - RandomNonzeroScalar(): Outputs a random non-zero `Scalar` element in GF(p).
-- SerializeElement(A): Maps an `Element` `A` to a unique byte array `buf` of fixed length `Ne`,
-  and fails if the input is not a valid byte representation of an element of
-  the group. This function can raise a SerializeError if serialization fails.
-  See {{ciphersuites}} for group-specific input validation steps. 
+- SerializeElement(A): Maps an `Element` `A` to a unique byte array `buf` of fixed length `Ne`.
 - DeserializeElement(buf): Attempts to map a byte array `buf` to an `Element` `A`,
   and fails if the input is not a valid byte representation of an element of
   the group. This function can raise a DeserializeError if deserialization fails.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -800,6 +800,8 @@ The value of the contextString parameter is empty.
 - Group: edwards25519 {{!RFC8032}}
   - Cofactor (`h`): 8
   - SerializeNonIdentityElement: Implemented as specified in {{!RFC8032, Section 5.1.2}}.
+    Additionally, this function validates that the resulting element is not the group
+    identity element.
   - DeserializeNonIdentityElement: Implemented as specified in {{!RFC8032, Section 5.1.3}}.
     Additionally, this function validates that the resulting element is not the group
     identity element.
@@ -850,6 +852,8 @@ The value of the contextString parameter is empty.
 - Group: edwards448 {{!RFC8032}}
   - Cofactor (`h`): 4
   - SerializeNonIdentityElement: Implemented as specified in {{!RFC8032, Section 5.2.2}}.
+    Additionally, this function validates that the resulting element is not the group
+    identity element.
   - DeserializeNonIdentityElement: Implemented as specified in {{!RFC8032, Section 5.2.3}}.
     Additionally, this function validates that the resulting element is not the group
     identity element.
@@ -879,6 +883,8 @@ The value of the contextString parameter is "FROST-P256-SHA256".
   - Cofactor (`h`): 1
   - SerializeNonIdentityElement: Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
     method according to {{SECG}}.
+    Additionally, this function validates that the resulting element is not the group
+    identity element.
   - DeserializeNonIdentityElement: Implemented by attempting to deserialize a public key using
     the compressed Octet-String-to-Elliptic-Curve-Point method according to {{SECG}},
     and then performs partial public-key validation as defined in section 5.6.2.3.4 of

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -800,8 +800,7 @@ The value of the contextString parameter is empty.
 - Group: edwards25519 {{!RFC8032}}
   - Cofactor (`h`): 8
   - SerializeNonIdentityElement: Implemented as specified in {{!RFC8032, Section 5.1.2}}.
-    Additionally, this function validates that the resulting element is not the group
-    identity element.
+    This function raises a SerializeError exception if the input is the identity element.
   - DeserializeNonIdentityElement: Implemented as specified in {{!RFC8032, Section 5.1.3}}.
     Additionally, this function validates that the resulting element is not the group
     identity element.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -488,7 +488,7 @@ This section describes the subroutine for creating the per-message challenge.
 
   def compute_challenge(group_commitment, group_public_key, msg):
     group_comm_enc = G.SerializeElement(group_commitment)
-    group_public_key_enc = G.SerializeElement(group_public_key)
+    group_public_key_enc = G.SerializePublicKey(group_public_key)
     challenge_input = group_comm_enc || group_public_key_enc || msg
     challenge = H2(challenge_input)
     return challenge

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -205,11 +205,8 @@ We now detail a number of member functions that can be invoked on `G`.
   and fails if the input is not a valid byte representation of an element of
   the group. This function can raise a DeserializeError if deserialization fails.
   See {{ciphersuites}} for group-specific input validation steps.
-- SerializeNonIdentityElement(A): Maps an `Element` `A` to a unique byte array `buf` of fixed length `Ne`,
-  and fails if the input is not a valid byte representation of an element of
-  the group. This function can raise a SerializeError if serialization fails
-  or `A` is the identity element of the group; see {{ciphersuites}} for group-specific
-  input validation steps.
+- SerializeNonIdentityElement(A): Maps an `Element` `A` to a unique byte array `buf` of fixed length `Ne`.
+  This function will raise a SerializeError if `A` is the identity element of the group.
 - DeserializeNonIdentityElement(buf): Attempts to map a byte array `buf` to an `Element` `A`,
   and fails if the input is not a valid byte representation of an element of
   the group. This function can raise a DeserializeError if deserialization fails

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -236,7 +236,6 @@ for more details about each.
 Beyond the core dependencies, the protocol in this document depends on the
 following helper operations:
 
-- Serializion of public key material {{dep-serialize-pk}}
 - Schnorr signatures, {{dep-schnorr}};
 - Polynomial operations, {{dep-polynomial}};
 - Encoding operations, {{dep-encoding}};

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -244,15 +244,7 @@ following helper operations:
 
 This sections describes these operations in more detail.
 
-## Serialization of Public Key Material {#dep-serialize-pk}
-
-Implementations may wish to sample public key material from a distribution that either includes 
-or rejects the identity element of the underlying group. To scope this choice to only public 
-key material, we define the following two alias functions. See {{dep-pog}} for more information.
-
-- SerializePublicKey(PK): Alias for *either* SerializeElement(A) or SerializeNonIdentity(A) as required by the application.
-- DeserializePublicKey(buf): Alias for *either* DeserializeElement(buf) or DeserializeNonIdentity(buf), as required by the application. 
-
+Finally, the protocol in this document uses the function `SerializePublicKey` as an alias for `SerializeElement`. 
 ## Schnorr Signature Operations {#dep-schnorr}
 
 In the single-party setting, a Schnorr signature is generated with the

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -197,7 +197,11 @@ We now detail a number of member functions that can be invoked on `G`.
 - Identity(): Outputs the identity `Element` of the group (i.e. `I`).
 - RandomScalar(): Outputs a random `Scalar` element in GF(p).
 - RandomNonzeroScalar(): Outputs a random non-zero `Scalar` element in GF(p).
-- SerializeElement(A): Maps an `Element` `A` to a unique byte array `buf` of fixed length `Ne`.
+- SerializeElement(A): Maps an `Element` `A` to a unique byte array `buf` of fixed length `Ne`,
+  and fails if the input is not a valid byte representation of an element of
+  the group. This function can raise a SerializeError if serialization fails
+  or `A` is the identity element of the group; see {{ciphersuites}} for group-specific
+  input validation steps.
 - DeserializeElement(buf): Attempts to map a byte array `buf` to an `Element` `A`,
   and fails if the input is not a valid byte representation of an element of
   the group. This function can raise a DeserializeError if deserialization fails

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -207,6 +207,19 @@ We now detail a number of member functions that can be invoked on `G`.
   the group. This function can raise a DeserializeError if deserialization fails
   or `A` is the identity element of the group; see {{ciphersuites}} for group-specific
   input validation steps.
+- SerializePublicKey(): Maps a public key Element` `PK` to a unique byte array `buf` of fixed length `Ne`,
+  and fails if the input is not a valid byte representation. `PK` can be the identity element,
+  to ensure uniform sampling of `sk` over `GF(p)`.
+- DeserializeElement(buf): Attempts to map a byte array `buf` to an `Element` `A`,
+  and fails if the input is not a valid byte representation of an element of
+  the group. This function can raise a DeserializeError if deserialization fails
+  or `A` is the identity element of the group; see {{ciphersuites}} for group-specific
+  input validation steps.
+- DeserializePublicKey(buf): Attempts to map a byte array `buf` to an `Element` `A`,
+  and fails if the input is not a valid byte representation of an element of
+  the group. This function can raise a DeserializeError if deserialization fails 
+  (but this element is allowed to be the identity);
+  see {{ciphersuites}} for group-specific input validation steps.
 - SerializeScalar(s): Maps a Scalar `s` to a unique byte array `buf` of fixed length `Ns`.
 - DeserializeScalar(buf): Attempts to map a byte array `buf` to a `Scalar` `s`.
   This function can raise a DeserializeError if deserialization fails; see
@@ -255,7 +268,7 @@ following operation.
     R = G.ScalarBaseMult(k)
 
     comm_enc = G.SerializeElement(R)
-    pk_enc = G.SerializeElement(PK)
+    pk_enc = G.SerializePublicKey(PK)
     challenge_input = comm_enc || pk_enc || msg
     c = H2(challenge_input)
 
@@ -281,7 +294,7 @@ MUST be performed when `h>1`.
 
   def schnorr_signature_verify(msg, sig = (R, z), PK):
     comm_enc = G.SerializeElement(R)
-    pk_enc = G.SerializeElement(PK)
+    pk_enc = G.SerializePublicKey(PK)
     challenge_input = comm_enc || pk_enc || msg
     c = H2(challenge_input)
 

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -805,6 +805,8 @@ The value of the contextString parameter is empty.
   - DeserializeNonIdentityElement: Implemented as specified in {{!RFC8032, Section 5.1.3}}.
     Additionally, this function validates that the resulting element is not the group
     identity element.
+  - SerializeElement: Implemented as specified in {{!RFC8032, Section 5.1.2}}.
+  - DeserializeElement: Implemented as specified in {{!RFC8032, Section 5.1.3}}.
   - SerializeScalar: Implemented by outputting the little-endian 32-byte encoding of
     the Scalar value.
   - DeserializeScalar: Implemented by attempting to deserialize a Scalar from a 32-byte
@@ -831,6 +833,8 @@ The value of the contextString parameter is "FROST-RISTRETTO255-SHA512".
   - Cofactor (`h`): 1
   - SerializeNonIdentityElement: Implemented using the 'Encode' function from {{!RISTRETTO}}.
   - DeserializeNonIdentityElement: Implemented using the 'Decode' function from {{!RISTRETTO}}.
+  - SerializeElement: Implemented using the 'Encode' function from {{!RISTRETTO}}.
+  - DeserializeElement: Implemented using the 'Decode' function from {{!RISTRETTO}}.
   - SerializeScalar: Implemented by outputting the little-endian 32-byte encoding of
     the Scalar value.
   - DeserializeScalar: Implemented by attempting to deserialize a Scalar from a 32-byte
@@ -857,6 +861,8 @@ The value of the contextString parameter is empty.
   - DeserializeNonIdentityElement: Implemented as specified in {{!RFC8032, Section 5.2.3}}.
     Additionally, this function validates that the resulting element is not the group
     identity element.
+  - SerializeElement: Implemented as specified in {{!RFC8032, Section 5.2.2}}.
+  - DeserializeElement: Implemented as specified in {{!RFC8032, Section 5.2.3}}.
   - SerializeScalar: Implemented by outputting the little-endian 48-byte encoding of
     the Scalar value.
   - DeserializeScalar: Implemented by attempting to deserialize a Scalar from a 48-byte
@@ -892,6 +898,15 @@ The value of the contextString parameter is "FROST-P256-SHA256".
     coordinates of the resulting point are in the correct range, that the point is on
     the curve, and that the point is not the point at infinity. Additionally, this function
     validates  that the resulting element is not the group identity element.
+    If these checks fail, deserialization returns an error.
+  - SerializeElement: Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
+    method according to {{SECG}}.
+  - DeserializeElement: Implemented by attempting to deserialize a public key using
+    the compressed Octet-String-to-Elliptic-Curve-Point method according to {{SECG}},
+    and then performs partial public-key validation as defined in section 5.6.2.3.4 of
+    {{!KEYAGREEMENT=DOI.10.6028/NIST.SP.800-56Ar3}}. This includes checking that the
+    coordinates of the resulting point are in the correct range, that the point is on
+    the curve, and that the point is not the point at infinity. 
     If these checks fail, deserialization returns an error.
   - SerializeScalar: Implemented using the Field-Element-to-Octet-String conversion
     according to {{SECG}}.


### PR DESCRIPTION
We need to specify different serialization/deserialization functions for public keys, which are allowed to be the identity element. 