### PR TITLE
Add Modular FROST as an implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is the working area for the individual Internet-Draft, "Two-Round Threshold
 | [Reference](https://github.com/cfrg/draft-irtf-cfrg-frost/tree/master/poc) | Sage     | All                            | main    |
 | [frost-ristretto255](https://github.com/ZcashFoundation/frost/tree/main/frost-ristretto255) | Rust     | FROST(ristretto255, SHA-512)                            | 03   |
 | [ecc](https://github.com/aldenml/ecc)                                      | C        | FROST(ristretto255, SHA-512)   | 02 |
+| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | C        | All except Ed448   | 05 |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is the working area for the individual Internet-Draft, "Two-Round Threshold
 | [Reference](https://github.com/cfrg/draft-irtf-cfrg-frost/tree/master/poc) | Sage     | All                            | main    |
 | [frost-ristretto255](https://github.com/ZcashFoundation/frost/tree/main/frost-ristretto255) | Rust     | FROST(ristretto255, SHA-512)                            | 03   |
 | [ecc](https://github.com/aldenml/ecc)                                      | C        | FROST(ristretto255, SHA-512)   | 02 |
-| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | C        | All except Ed448   | 05 |
+| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | Rust     | All except FROST(Ed448, SHAKE256)   | 05 |
 
 ## Contributing
 


### PR DESCRIPTION
Instead of listing as `FROST(Ed25519, SHA-512, FROST(ristretto255, SHA-512), FROST(P-256, SHA-256)`, I listed as `All except FROST(Ed448, SHAKE256)` to be succinct. It should be noted this is a modular library, being usable for a variety of Schnorr-like constructions, with non-standard functionality offered directly in it already (key offsetting for HDKD/privacy schemes), yet a Schnorr algorithm and IETF HRAMs are provided.

This does pass the v5 vectors, as proven with these files:
https://github.com/serai-dex/serai/blob/develop/crypto/frost/src/tests/literal/kp256.rs
https://github.com/serai-dex/serai/blob/develop/crypto/frost/src/tests/literal/dalek.rs

Though as my other issue noted, this isn't technically a v5 implementation, due to a discrepancy which will be resolved in v6. I believe it is an implementation of the current develop branch however.