### PR TITLE
Note that RandomScalar should use rejection sampling

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -886,8 +886,8 @@ The value of the contextString parameter is empty.
 - Group: edwards25519 {{!RFC8032}}
   - Order: 2^252 + 27742317777372353535851937790883648493 (see {{?RFC7748}})
   - Identity: As defined in {{RFC7748}}.
-  - RandomScalar: Implemented by generating a random 32-byte string and invoking
-    DeserializeScalar on the result.
+  - RandomScalar: Implemented by repeatedly generating a random 32-byte string
+    and invoking DeserializeScalar on the result until success.
   - SerializeElement: Implemented as specified in {{!RFC8032, Section 5.1.2}}.
   - DeserializeElement: Implemented as specified in {{!RFC8032, Section 5.1.3}}.
     Additionally, this function validates that the resulting element is not the group
@@ -920,8 +920,8 @@ The value of the contextString parameter is "FROST-RISTRETTO255-SHA512-v5".
 - Group: ristretto255 {{!RISTRETTO=I-D.irtf-cfrg-ristretto255-decaf448}}
   - Order: 2^252 + 27742317777372353535851937790883648493 (see {{RISTRETTO}})
   - Identity: As defined in {{RISTRETTO}}.
-  - RandomScalar: Implemented by generating a random 32-byte string and invoking
-    DeserializeScalar on the result.
+  - RandomScalar: Implemented by repeatedly generating a random 32-byte string and
+    invoking DeserializeScalar on the result until success.
   - SerializeElement: Implemented using the 'Encode' function from {{!RISTRETTO}}.
   - DeserializeElement: Implemented using the 'Decode' function from {{!RISTRETTO}}.
   - SerializeScalar: Implemented by outputting the little-endian 32-byte encoding of
@@ -947,8 +947,8 @@ The value of the contextString parameter is empty.
 - Group: edwards448 {{!RFC8032}}
   - Order: 2^446 - 13818066809895115352007386748515426880336692474882178609894547503885
   - Identity: As defined in {{RFC7748}}.
-  - RandomScalar: Implemented by generating a random 48-byte string and invoking
-    DeserializeScalar on the result.
+  - RandomScalar: Implemented by repeatedly generating a random 48-byte string and
+    invoking DeserializeScalar on the result until success.
   - SerializeElement: Implemented as specified in {{!RFC8032, Section 5.2.2}}.
   - DeserializeElement: Implemented as specified in {{!RFC8032, Section 5.2.3}}.
     Additionally, this function validates that the resulting element is not the group
@@ -981,8 +981,8 @@ The value of the contextString parameter is "FROST-P256-SHA256-v5".
 - Group: P-256 (secp256r1) {{x9.62}}
   - Order: 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551
   - Identity: As defined in {{x9.62}}.
-  - RandomScalar: Implemented by generating a random 32-byte string and invoking
-    DeserializeScalar on the result.
+  - RandomScalar: Implemented by repeatedly generating a random 32-byte string
+    and invoking DeserializeScalar on the result until success.
   - SerializeElement: Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
     method according to {{SECG}}.
   - DeserializeElement: Implemented by attempting to deserialize a public key using


### PR DESCRIPTION
Since DeserializeScalar is fallible, just retry if it fails.