### PR TITLE
Correct torsion check definition

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -894,7 +894,7 @@ The value of the contextString parameter is empty.
   - DeserializeElement: Implemented as specified in {{!RFC8032, Section 5.1.3}}.
     Additionally, this function validates that the resulting element is not the group
     identity element and is in the prime-order subgroup. The latter check can
-    be implemented by multiplying the resulting point by the curve order and
+    be implemented by multiplying the resulting point by the order of the group and
     checking that the result is the identity element.
   - SerializeScalar: Implemented by outputting the little-endian 32-byte encoding of
     the Scalar value.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -894,8 +894,8 @@ The value of the contextString parameter is empty.
   - DeserializeElement: Implemented as specified in {{!RFC8032, Section 5.1.3}}.
     Additionally, this function validates that the resulting element is not the group
     identity element and is in the prime-order subgroup. The latter check can
-    be implemented by multiplying the resulting point by the cofactor (8) and
-    checking that the result is not the identity element.
+    be implemented by multiplying the resulting point by the curve order and
+    checking that the result is the identity element.
   - SerializeScalar: Implemented by outputting the little-endian 32-byte encoding of
     the Scalar value.
   - DeserializeScalar: Implemented by attempting to deserialize a Scalar from a 32-byte


### PR DESCRIPTION
```rs
#[test]
fn torsion() {
  use curve25519_dalek::{
    traits::IsIdentity,
    constants::{ED25519_BASEPOINT_TABLE, EIGHT_TORSION},
    scalar::Scalar
  };
  let point = (&Scalar::from(5u8) * &ED25519_BASEPOINT_TABLE) + EIGHT_TORSION[7];
  assert!(!point.mul_by_cofactor().is_identity());
  assert!(!point.is_torsion_free());
}
```

https://github.com/dalek-cryptography/curve25519-dalek/blob/967d8b6c0e67100401ad66125b7399ccf509ae22/src/edwards.rs#L1184-L1186

The existing definition checks it's non-0, even when torsioned. It does not check it is in the prime order subgroup.