### PR TITLE
Update modular-frost's version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is the working area for the individual Internet-Draft, "Two-Round Threshold
 | [frost-ristretto255](https://github.com/ZcashFoundation/frost/tree/main/frost-ristretto255) | Rust     | FROST(ristretto255, SHA-512)                            | 04   |
 | [frost-p256](https://github.com/ZcashFoundation/frost/tree/main/frost-p256) | Rust     | FROST(P-256, SHA-256)                            | 04   |
 | [ecc](https://github.com/aldenml/ecc)                                      | C        | FROST(ristretto255, SHA-512)   | 02 |
-| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | Rust     | All except FROST(Ed448, SHAKE256)   | 05 |
+| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | Rust     | All except FROST(Ed448, SHAKE256)   | 07 |
 
 ## Contributing
 


### PR DESCRIPTION
Updated in https://github.com/serai-dex/serai/commit/94f380f8575d4d3bdaa60483f384e8cd4a6fbbc9#diff-a133540275715be103deeb55f161a7a3172e85acd9b1e57a3269b7e62a7a16df, with the link being to the vectors being moved to v7's.