### PR TITLE
Add IdentifierToScalar method

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -244,6 +244,8 @@ of the group. Scalar base multiplication is equivalent to the repeated applicati
 operation `B` with itself `r-1` times, this is denoted as `ScalarBaseMult(r)`. The set of
 scalars corresponds to `GF(p)`, which we refer to as the scalar field. This document uses types
 `Element` and `Scalar` to denote elements of the group `G` and its set of scalars, respectively.
+We denote Scalar(x) as the conversion of integer input `x` to the corresponding Scalar value with
+the same numeric value. For example, Scalar(1) yields a Scalar representing the value 1.
 We denote equality comparison as `==` and assignment of values by `=`.
 
 We now detail a number of member functions that can be invoked on `G`.
@@ -261,8 +263,6 @@ We now detail a number of member functions that can be invoked on `G`.
 - DeserializeScalar(buf): Attempts to map a byte array `buf` to a `Scalar` `s`.
   This function can raise a DeserializeError if deserialization fails; see
   {{ciphersuites}} for group-specific input validation steps.
-- IdentifierToScalar(i): Maps an identifier `i` to a Scalar with the same numeric
-  value (e.g. the identifier 1 must be mapped into the Scalar 1).
 
 ## Cryptographic Hash Function {#dep-hash}
 
@@ -736,7 +736,7 @@ procedure to produce its own signature share.
 
     # Compute Lagrange coefficient
     participant_list = participants_from_commitment_list(commitment_list)
-    lambda_i = derive_lagrange_coefficient(G.IdentifierToScalar(identifier), participant_list)
+    lambda_i = derive_lagrange_coefficient(Scalar(identifier), participant_list)
 
     # Compute the per-message challenge
     challenge = compute_challenge(group_commitment, group_public_key, msg)
@@ -809,7 +809,7 @@ parameters, to check that the signature share is valid using the following proce
 
     # Compute Lagrange coefficient
     participant_list = participants_from_commitment_list(commitment_list)
-    lambda_i = derive_lagrange_coefficient(G.IdentifierToScalar(identifier), participant_list)
+    lambda_i = derive_lagrange_coefficient(Scalar(identifier), participant_list)
 
     # Compute relation values
     l = G.ScalarBaseMult(sig_share_i)
@@ -1239,7 +1239,7 @@ The procedure for splitting a secret into shares is as follows.
     # Evaluate the polynomial for each point x=1,...,n
     secret_key_shares = []
     for x_i in range(1, MAX_SIGNERS + 1):
-      y_i = polynomial_evaluate(G.IdentifierToScalar(x_i), coefficients)
+      y_i = polynomial_evaluate(Scalar(x_i), coefficients)
       secret_key_share_i = (x_i, y_i)
       secret_key_share.append(secret_key_share_i)
     return secret_key_shares, coefficients
@@ -1269,7 +1269,7 @@ secret `s` is as follows.
   def secret_share_combine(shares):
     if len(shares) < MIN_SIGNERS:
       raise "invalid parameters"
-    scalar_shares = [(G.IdentifierToScalar(x), y) for x, y in shares]
+    scalar_shares = [(Scalar(x), y) for x, y in shares]
     s = polynomial_interpolation(scalar_shares)
     return s
 ~~~


### PR DESCRIPTION
This is a suggestion to make it explicit the conversion between identifiers and scalars, to reduce the chance of implementation mistakes.

Another possible approaches:

- Make `derive_lagrange_coefficient` and `polynomial_evaluate` receive identifiers and convert to Scalars inside them. Makes calling them easier, but conceptually weird since those seem to be "arithmetic" functions
- Specify that identifier are Scalars. This will require changing `encode_uint16` to receive a Scalar, and implementors would need to guarantee that identifier Scalars are in the correct range, which is awkward.