### PR TITLE
Change RandomScalar to not specify a particular implementation

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -1694,6 +1694,6 @@ the array has 256; thus the top 3 bits of the last byte can be set to zero.
 
 ## Wide Reduction
 
-Generate a random byte array with `Ns * 2` bytes, and interpret it as a
-little-endian integer; reduce the integer modulo `G.Order()` and return the
+Generate a random byte array with `L = ceil(((3 * ceil(log2(G.Order()))) / 2) / 8)`
+bytes, and interpret it as an integer; reduce the integer modulo `G.Order()` and return the
 result.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -1353,6 +1353,31 @@ which is an input into the FROST signing protocol.
       return PK, signer_public_keys
 ~~~
 
+# Random Scalar Generation {#random-scalar}
+
+Two popular algorithms for generating a random integer uniformly distributed in
+the range \[0, G.Order() -1\] are as follows:
+
+## Rejection Sampling
+
+Generate a random byte array with `Ns` bytes, and attempt to map to a Scalar
+by calling `DeserializeScalar`. If it works, return the result. If it fails,
+try again with another random byte array, until the procedure succeeds.
+
+Note the that the Scalar size might be some bits smaller than the array size,
+which can result in the loop iterating more times than required. In that case
+it's acceptable to set the high-order bits to 0 before calling `DeserializeScalar`,
+but care must be taken to not set to zero more bits than required. For example,
+in the `FROST(Ed25519, SHA-512)` ciphersuite, the order has 253 bits while
+the array has 256; thus the top 3 bits of the last byte can be set to zero.
+
+## Wide Reduction
+
+Generate a random byte array with `L = ceil(((3 * ceil(log2(G.Order()))) / 2) / 8)`
+bytes, and interpret it as an integer; reduce the integer modulo `G.Order()` and return the
+result.
+
+
 # Test Vectors
 
 This section contains test vectors for all ciphersuites listed in {{ciphersuites}}.
@@ -1672,28 +1697,3 @@ S3 sig_share: 9651d355ca1dea2557ba1f73e38a9f4ff1f1afc565323ef27f88a9d
 sig: 02dfba781e17b830229ae4ed22ebe402873683d9dfd945d01762217fb3172c2a
 71f83a8d1a3efd188c04d41cf48a716e11b8eff38607023c1f9bb0d36fe1d9f2e9
 ~~~
-
-
-# Random Scalar Generation {#random-scalar}
-
-Two popular algorithms for generating a random integer uniformly distributed in
-the range \[0, G.Order() -1\] are as follows:
-
-## Rejection Sampling
-
-Generate a random byte array with `Ns` bytes, and attempt to map to a Scalar
-by calling `DeserializeScalar`. If it works, return the result. If it fails,
-try again with another random byte array, until the procedure succeeds.
-
-Note the that the Scalar size might be some bits smaller than the array size,
-which can result in the loop iterating more times than required. In that case
-it's acceptable to set the high-order bits to 0 before calling `DeserializeScalar`,
-but care must be taken to not set to zero more bits than required. For example,
-in the `FROST(Ed25519, SHA-512)` ciphersuite, the order has 253 bits while
-the array has 256; thus the top 3 bits of the last byte can be set to zero.
-
-## Wide Reduction
-
-Generate a random byte array with `L = ceil(((3 * ceil(log2(G.Order()))) / 2) / 8)`
-bytes, and interpret it as an integer; reduce the integer modulo `G.Order()` and return the
-result.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -923,7 +923,7 @@ The value of the contextString parameter is "FROST-RISTRETTO255-SHA512-v5".
 - Group: ristretto255 {{!RISTRETTO=I-D.irtf-cfrg-ristretto255-decaf448}}
   - Order: 2^252 + 27742317777372353535851937790883648493 (see {{RISTRETTO}})
   - Identity: As defined in {{RISTRETTO}}.
-  - RandomScalar: Implemented by returning a uniformbly random Scalar in the range
+  - RandomScalar: Implemented by returning a uniformly random Scalar in the range
     \[0, `G.Order()` - 1\]. Refer to {{random-scalar}} for implementation guidance.
   - SerializeElement: Implemented using the 'Encode' function from {{!RISTRETTO}}.
   - DeserializeElement: Implemented using the 'Decode' function from {{!RISTRETTO}}.
@@ -953,7 +953,7 @@ The value of the contextString parameter is empty.
 - Group: edwards448 {{!RFC8032}}
   - Order: 2^446 - 13818066809895115352007386748515426880336692474882178609894547503885
   - Identity: As defined in {{RFC7748}}.
-  - RandomScalar: Implemented by returning a uniformbly random Scalar in the range
+  - RandomScalar: Implemented by returning a uniformly random Scalar in the range
     \[0, `G.Order()` - 1\]. Refer to {{random-scalar}} for implementation guidance.
   - SerializeElement: Implemented as specified in {{!RFC8032, Section 5.2.2}}.
   - DeserializeElement: Implemented as specified in {{!RFC8032, Section 5.2.3}}.
@@ -992,7 +992,7 @@ The value of the contextString parameter is "FROST-P256-SHA256-v5".
 - Group: P-256 (secp256r1) {{x9.62}}
   - Order: 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551
   - Identity: As defined in {{x9.62}}.
-  - RandomScalar: Implemented by returning a uniformbly random Scalar in the range
+  - RandomScalar: Implemented by returning a uniformly random Scalar in the range
     \[0, `G.Order()` - 1\]. Refer to {{random-scalar}} for implementation guidance.
   - SerializeElement: Implemented using the compressed Elliptic-Curve-Point-to-Octet-String
     method according to {{SECG}}.
@@ -1676,7 +1676,7 @@ sig: 02dfba781e17b830229ae4ed22ebe402873683d9dfd945d01762217fb3172c2a
 
 # Random Scalar Generation {#random-scalar}
 
-Two popular algorithms for generating a random integer uniformbly distributed in
+Two popular algorithms for generating a random integer uniformly distributed in
 the range \[0, G.Order() -1\] are as follows:
 
 ## Rejection Sampling

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -1361,7 +1361,7 @@ the range \[0, G.Order() -1\] are as follows:
 ## Rejection Sampling
 
 Generate a random byte array with `Ns` bytes, and attempt to map to a Scalar
-by calling `DeserializeScalar`. If it works, return the result. If it fails,
+by calling `DeserializeScalar`. If it succeeds, return the result. If it fails,
 try again with another random byte array, until the procedure succeeds.
 
 Note the that the Scalar size might be some bits smaller than the array size,
@@ -1375,7 +1375,7 @@ the array has 256; thus the top 3 bits of the last byte can be set to zero.
 
 Generate a random byte array with `L = ceil(((3 * ceil(log2(G.Order()))) / 2) / 8)`
 bytes, and interpret it as an integer; reduce the integer modulo `G.Order()` and return the
-result.
+result. See {{Section 5 of HASH-TO-CURVE}} for the underlying derivation of `L`.
 
 
 # Test Vectors

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -882,7 +882,7 @@ The value of the contextString parameter is empty.
 - Group: edwards25519 {{!RFC8032}}
   - Order: 2^252 + 27742317777372353535851937790883648493 (see {{?RFC7748}})
   - Identity: As defined in {{RFC7748}}.
-  - RandomScalar: Implemented by returning a uniformbly random Scalar in the range
+  - RandomScalar: Implemented by returning a uniformly random Scalar in the range
     \[0, `G.Order()` - 1\]. Refer to {{random-scalar}} for implementation guidance.
   - SerializeElement: Implemented as specified in {{!RFC8032, Section 5.1.2}}.
   - DeserializeElement: Implemented as specified in {{!RFC8032, Section 5.1.3}}.


### PR DESCRIPTION
This also came up while reviewing the https://github.com/ZcashFoundation/zips/pull/3/.

It's an attempt to not force a particular implementation approach in RandomScalar while still providing implementation guidance.

But feel free to reject this if it's not a good idea.