### PR TITLE
mention in aggregate that the signers are from the previous rounds

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -835,16 +835,15 @@ any signer share, the Coordinator MUST abort the protocol for correctness reason
 Excluding one signer means that their nonce will not be included in the joint response `z`
 and consequently the output signature will not verify.
 
-Otherwise, if all signer shares are valid, the Coordinator performs the `aggregate` operation
-and publishes the resulting signature.
+Otherwise, if all shares from signers that participated in Rounds 1 and 2 are valid, the Coordinator
+performs the `aggregate` operation and publishes the resulting signature.
 
 ~~~
   Inputs:
   - group_commitment, the group commitment returned by compute_group_commitment,
     an Element in G.
-  - sig_shares, a set of signature shares z_i, Scalar values, for each signer
-    that participated in Rounds 1 and 2, of length NUM_SIGNERS, where
-    MIN_SIGNERS <= NUM_SIGNERS <= MAX_SIGNERS.
+  - sig_shares, a set of signature shares z_i, Scalar values, for each signer,
+    of length NUM_SIGNERS, where MIN_SIGNERS <= NUM_SIGNERS <= MAX_SIGNERS.
 
   Outputs: (R, z), a Schnorr signature consisting of an Element R and Scalar z.
 

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -842,8 +842,9 @@ and publishes the resulting signature.
   Inputs:
   - group_commitment, the group commitment returned by compute_group_commitment,
     an Element in G.
-  - sig_shares, a set of signature shares z_i, Scalar values, for each signer,
-    of length NUM_SIGNERS, where MIN_SIGNERS <= NUM_SIGNERS <= MAX_SIGNERS.
+  - sig_shares, a set of signature shares z_i, Scalar values, for each signer
+    that participated in Rounds 1 and 2, of length NUM_SIGNERS, where
+    MIN_SIGNERS <= NUM_SIGNERS <= MAX_SIGNERS.
 
   Outputs: (R, z), a Schnorr signature consisting of an Element R and Scalar z.
 


### PR DESCRIPTION
This is a minor clarity issue that came up while reviewing  https://github.com/ZcashFoundation/zips/pull/3 (this is the last one! :rofl: )

Feel free to reject / modify if preferred.