### PR TITLE
Update modular-frost to v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is the working area for the individual Internet-Draft, "Two-Round Threshold
 | [frost-ristretto255](https://github.com/ZcashFoundation/frost/tree/main/frost-ristretto255) | Rust     | FROST(ristretto255, SHA-512)                            | 04   |
 | [frost-p256](https://github.com/ZcashFoundation/frost/tree/main/frost-p256) | Rust     | FROST(P-256, SHA-256)                            | 04   |
 | [ecc](https://github.com/aldenml/ecc)                                      | C        | FROST(ristretto255, SHA-512)   | 02 |
-| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | Rust     | All except FROST(Ed448, SHAKE256)   | 07 |
+| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | Rust     | All except FROST(Ed448, SHAKE256)   | 08 |
 
 ## Contributing
 


### PR DESCRIPTION
Sorry for the delay in doing so. This was tagged yet not marked as a release so I missed it. Really should've subbed to the mailing list...

https://github.com/serai-dex/serai/commit/a8a00598e4e6f44746b5d971eec5f547d4df35c5 for the commit updating the vectors, which does pass the CI.