### PR TITLE
Note that rejection sampling should be done in constant time

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -1455,8 +1455,10 @@ the range \[0, G.Order() -1\] are as follows:
 ## Rejection Sampling
 
 Generate a random byte array with `Ns` bytes, and attempt to map to a Scalar
-by calling `DeserializeScalar`. If it succeeds, return the result. If it fails,
-try again with another random byte array, until the procedure succeeds.
+by calling `DeserializeScalar` in constant time. If it succeeds, return the
+result. If it fails, try again with another random byte array, until the
+procedure succeeds. Failure to implement this in constant time can leak information
+about the underlying corresponding Scalar.
 
 Note the that the Scalar size might be some bits smaller than the array size,
 which can result in the loop iterating more times than required. In that case


### PR DESCRIPTION
I chose not to make special accommodations for curves whose order is close to a power of two. It just seems like more words for something that's a pretty minimal optimization.

Closes #266.

cc @pornin