### PR TITLE
Update modular-frost to v10 with all ciphersuites

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is the working area for the individual Internet-Draft, "Two-Round Threshold
 | [frost-ristretto255](https://github.com/ZcashFoundation/frost/tree/main/frost-ristretto255) | Rust     | FROST(ristretto255, SHA-512)                            | 04   |
 | [frost-p256](https://github.com/ZcashFoundation/frost/tree/main/frost-p256) | Rust     | FROST(P-256, SHA-256)                            | 04   |
 | [ecc](https://github.com/aldenml/ecc)                                      | C        | FROST(ristretto255, SHA-512)   | 02 |
-| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | Rust     | All except FROST(Ed448, SHAKE256)   | 08 |
+| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | Rust     | All   | 10 |
 | [crrl](https://github.com/pornin/crrl/blob/main/src/frost.rs)               | Rust     | All except FROST(Ed448, SHAKE256)    | 08 |
 
 ## Contributing


### PR DESCRIPTION
https://github.com/serai-dex/serai/commit/2b7c9378c0ee4d43d8562153874b9cc9dcb5d932 for the commit doing so, which includes the new vectors and passes CI. The crate has also been pushed to crates.io.