### PR TITLE
Mark modular-frost as v11 compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is the working area for the individual Internet-Draft, "Two-Round Threshold
 | [frost-ristretto255](https://github.com/ZcashFoundation/frost/tree/main/frost-ristretto255) | Rust     | FROST(ristretto255, SHA-512)                            | 04   |
 | [frost-p256](https://github.com/ZcashFoundation/frost/tree/main/frost-p256) | Rust     | FROST(P-256, SHA-256)                            | 04   |
 | [ecc](https://github.com/aldenml/ecc)                                      | C        | FROST(ristretto255, SHA-512)   | 02 |
-| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | Rust     | All   | 10 |
+| [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | Rust     | All   | 11 |
 | [crrl](https://github.com/pornin/crrl/blob/main/src/frost.rs)               | Rust     | All except FROST(Ed448, SHAKE256)    | 08 |
 
 ## Contributing


### PR DESCRIPTION
https://github.com/serai-dex/serai/commit/a0a54eb0de0b37bfcaee73bec324624bb1f1b852, which now directly includes the test vectors, and https://github.com/serai-dex/serai/commit/9d376d29e12150136aa1ae54c6931e3e420ac5a1, which includes a passing CI run. The delay in the two is because there was unrelated CI issues.

The crate is published.

Since v11 made minimal functional changes, I debated not bothering with a PR, yet doing so seems minor enough that it's best to keep all ducks in a row.