### PR TITLE
clarify how group info is used in verify_signature_share

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -834,7 +834,8 @@ about dealing with invalid signatures and misbehaving participants.
 
 The function for verifying a signature share, denoted `verify_signature_share`, is described below.
 Recall that the Coordinator is configured with "group info" which contains
-the group public key `PK` and public keys `PK_i` for each participant.
+the group public key `PK` and public keys `PK_i` for each participant, so the `group_public_key` and
+`PK_i` function arguments should come from that previously stored group info.
 
 ~~~
   Inputs:


### PR DESCRIPTION
Closes https://github.com/cfrg/draft-irtf-cfrg-frost/issues/387