### PR TITLE
update c implementation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is the working area for the individual Internet-Draft, "Two-Round Threshold
 | [Reference](https://github.com/cfrg/draft-irtf-cfrg-frost/tree/master/poc) | Sage     | All                            | main    |
 | [frost-ristretto255](https://github.com/ZcashFoundation/frost/tree/main/frost-ristretto255) | Rust     | FROST(ristretto255, SHA-512)                            | 04   |
 | [frost-p256](https://github.com/ZcashFoundation/frost/tree/main/frost-p256) | Rust     | FROST(P-256, SHA-256)                            | 04   |
-| [ecc](https://github.com/aldenml/ecc)                                      | C        | FROST(ristretto255, SHA-512)   | 02 |
+| [ecc](https://github.com/aldenml/ecc)                                      | C        | FROST(ristretto255, SHA-512)   | main |
 | [modular-frost](https://github.com/serai-dex/serai/tree/develop/crypto/frost) | Rust     | All   | 11 |
 | [crrl](https://github.com/pornin/crrl/blob/main/src/frost.rs)               | Rust     | All except FROST(Ed448, SHAKE256)    | 08 |
 


### PR DESCRIPTION
Quite a difference `v02` -> `main` :)

Relevant files:

https://github.com/aldenml/ecc/blob/master/src/frost.h
https://github.com/aldenml/ecc/blob/master/src/frost.c
https://github.com/aldenml/ecc/blob/master/test/test_frost.c

Test vectors (copied from this repo `master` branch):

https://github.com/aldenml/ecc/blob/master/test/data/frost/frost-ristretto255-sha512.json
