### PR TITLE
define byte

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -238,7 +238,7 @@ draft-00
 
 The following notation is used throughout the document.
 
-* Byte: A sequence of eight bits.
+* byte: A sequence of eight bits.
 * `random_bytes(n)`: Outputs `n` bytes, sampled uniformly at random
 using a cryptographically secure pseudorandom number generator (CSPRNG).
 * `count(i, L)`: Outputs the number of times the element `i` is represented in the list `L`.

--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -238,6 +238,7 @@ draft-00
 
 The following notation is used throughout the document.
 
+* Byte: A sequence of eight bits.
 * `random_bytes(n)`: Outputs `n` bytes, sampled uniformly at random
 using a cryptographically secure pseudorandom number generator (CSPRNG).
 * `count(i, L)`: Outputs the number of times the element `i` is represented in the list `L`.


### PR DESCRIPTION
I went for the simplest thing, but we can define and use "octet" instead.

Closes #407