### PR TITLE
fix the order of secp256k1

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -1161,7 +1161,7 @@ This ciphersuite uses secp256k1 for the Group and SHA-256 for the Hash function 
 The value of the contextString parameter is "FROST-secp256k1-SHA256-v11".
 
 - Group: secp256k1 {{SEC2}}, where Ne = 33 and Ns = 32.
-  - Order(): Return 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551.
+  - Order(): Return 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141.
   - Identity(): As defined in {{SEC2}}.
   - RandomScalar(): Implemented by returning a uniformly random Scalar in the range
     \[0, `G.Order()` - 1\]. Refer to {{random-scalar}} for implementation guidance.


### PR DESCRIPTION
I decided to double check the constants and indeed there was a mistake, it had the P-256 order.

Here I checked all the orders (by copying and pasting the order from our spec in the left hand side, and from the normative spec in the right hand side):

```
sage: 2^252 + 27742317777372353535851937790883648493 == 2^252 + 0x14def9dea2f79cd65812631a5cf5d3ed
True
sage: 2^252 + 27742317777372353535851937790883648493 == 2^252 + 27742317777372353535851937790883648493
True
sage: 2^446 - 13818066809895115352007386748515426880336692474882178609894547503885 == 2^446 - 0x8335dc163bb124b65129c9
....: 6fde933d8d723a70aadc873d6d54a7bb0d
True
sage: 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551 == 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAAD
....: A7179E84F3B9CAC2FC632551
True
sage: 0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551 == 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6
....: AF48A03BBFD25E8CD0364141
False
# (after fixing it...)
sage: 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141 == 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6
....: AF48A03BBFD25E8CD0364141
True
```