### PR TITLE
Option to receive message to be signed later without a Coordinator

### DIFF
--- a/draft-irtf-cfrg-frost.md
+++ b/draft-irtf-cfrg-frost.md
@@ -1313,7 +1313,8 @@ Doing so does not change the security implications of FROST, but instead simply
 requires each participant to communicate with all other participants. We loosely
 describe how to perform FROST signing among participants without this coordinator role.
 We assume that every participant receives as input from an external source the
-message to be signed prior to performing the protocol.
+message to be signed prior to performing the protocol, or between rounds one and two
+of the protocol.
 
 Every participant begins by performing `commit()` as is done in the setting
 where a Coordinator is used. However, instead of sending the commitment


### PR DESCRIPTION
This change proposes an alternative Coordinator-less scenario:

1. Participants commit()
2. Participants receive message to be signed
3. Participants sign() and aggregate()

I don’t yet see a security disadvantage to this.